### PR TITLE
Fix for insert_legacy_redirect checks

### DIFF
--- a/wpcom-legacy-redirector.php
+++ b/wpcom-legacy-redirector.php
@@ -73,7 +73,7 @@ class WPCOM_Legacy_Redirector {
  	 */
 	static function insert_legacy_redirect( $from_url, $redirect_to ) {
 
-		if ( !( defined( WP_CLI ) && WP_CLI ) && !is_admin() ) {
+		if ( ! ( defined( 'WP_CLI' ) && WP_CLI ) && ! is_admin() && ! apply_filters( 'wpcom_legacy_redirector_allow_insert', false ) ) {
 			// never run on the front end
 			return false;
 		}


### PR DESCRIPTION
At the start of insert_legacy_redirect it checks for if WP_CLI is defined. However, the defined function expects a string value. Also added new filter wpcom_legacy_redirector_allow_insert to override the creation of redirect checks.

Also fixed some WP coding standard issues. 