### PR TITLE
Fixed php notice Undefined variable $row at line number 98

### DIFF
--- a/includes/wp-cli.php
+++ b/includes/wp-cli.php
@@ -93,6 +93,7 @@ class WPCOM_Legacy_Redirector_CLI extends WP_CLI_Command {
 		}
 
 		global $wpdb;
+		$row = 0;
 		if ( ( $handle = fopen( $assoc_args['csv'], "r" ) ) !== FALSE ) {
 			while ( ( $data = fgetcsv( $handle, 2000, "," ) ) !== FALSE ) {
 				$row++;


### PR DESCRIPTION
Fix for: 
Notice: Undefined variable: row in /Applications/../wp-content/plugins/WPCOM-Legacy-Redirector-master/includes/wp-cli.php on line 98
