### PR TITLE
Addition of `wpcom_legacy_redirector_preserve_query_params` filter to…

### DIFF
--- a/tests/test-redirects.php
+++ b/tests/test-redirects.php
@@ -55,4 +55,49 @@ class WpcomLegacyRedirectsTest extends WP_UnitTestCase {
 		$redirect = WPCOM_Legacy_Redirector::get_redirect_uri( $from );
 		$this->assertEquals( $redirect, $to, 'get_redirect_uri failed' );
 	}
+
+
+    public function get_protected_redirect_data() {
+        return array(
+            'redirect_simple_protected' => array(
+                '/simple-redirectA',
+                'http://example.com',
+                'simple-redirect/?utm_source=XYZ',
+                'http://example.com/?utm_source=XYZ'
+            ),
+
+            'redirect_protected_with_querystring' => array(
+                '/b-redirect?with=query-string',
+                'http://example.com',
+                '/b-redirect?with=query-string&utm_medium=123',
+                'http://example.com/?utm_medium=123'
+            ),
+
+            'redirect_protected_with_hashes' => array(
+                // The plugin should strip the hash and only store the URL path.
+                '/hash-redirectA#with-hash',
+                'http://example.com',
+                '/hash-redirectA#with-hash/?utm_source=SDF',
+                'http://example.com/?utm_source=SDF'
+            ),
+
+            'redirect_multiple_protected' => array(
+                '/simple-redirectC',
+                'http://example.com',
+                'simple-redirectC/?utm_source=XYZ&utm_medium=FALSE&utm_campaign=543',
+                'http://example.com/?utm_source=XYZ&utm_medium=FALSE&utm_campaign=543'
+            )
+        );
+    }
+
+    /**
+     * @dataProvider get_protected_redirect_data
+     */
+	function test_protected_query_redirect( $from, $to, $protected_from, $protected_to ) {
+        $redirect = WPCOM_Legacy_Redirector::insert_legacy_redirect( $from, $to );
+        $this->assertTrue( $redirect, 'insert_legacy_redirect failed' );
+
+        $redirect = WPCOM_Legacy_Redirector::get_redirect_uri( $protected_from );
+        $this->assertEquals( $redirect, $protected_to, 'get_redirect_uri failed' );
+    }
 }

--- a/tests/test-redirects.php
+++ b/tests/test-redirects.php
@@ -77,7 +77,7 @@ class WpcomLegacyRedirectsTest extends WP_UnitTestCase {
                 // The plugin should strip the hash and only store the URL path.
                 '/hash-redirectA/#with-hash',
                 'http://example.com/',
-                '/hash-redirectA#with-hash/?utm_source=SDF',
+                '/hash-redirectA/#with-hash?utm_source=SDF',
                 'http://example.com/?utm_source=SDF'
             ),
 

--- a/tests/test-redirects.php
+++ b/tests/test-redirects.php
@@ -60,30 +60,30 @@ class WpcomLegacyRedirectsTest extends WP_UnitTestCase {
     public function get_protected_redirect_data() {
         return array(
             'redirect_simple_protected' => array(
-                '/simple-redirectA',
-                'http://example.com',
+                '/simple-redirectA/',
+                'http://example.com/',
                 '/simple-redirectA/?utm_source=XYZ',
                 'http://example.com/?utm_source=XYZ'
             ),
 
             'redirect_protected_with_querystring' => array(
-                '/b-redirect?with=query-string',
-                'http://example.com',
-                '/b-redirect?with=query-string&utm_medium=123',
+                '/b-redirect/?with=query-string',
+                'http://example.com/',
+                '/b-redirect/?with=query-string&utm_medium=123',
                 'http://example.com/?utm_medium=123'
             ),
 
             'redirect_protected_with_hashes' => array(
                 // The plugin should strip the hash and only store the URL path.
-                '/hash-redirectA#with-hash',
-                'http://example.com',
+                '/hash-redirectA/#with-hash',
+                'http://example.com/',
                 '/hash-redirectA#with-hash/?utm_source=SDF',
                 'http://example.com/?utm_source=SDF'
             ),
 
             'redirect_multiple_protected' => array(
-                '/simple-redirectC',
-                'http://example.com',
+                '/simple-redirectC/',
+                'http://example.com/',
                 '/simple-redirectC/?utm_source=XYZ&utm_medium=FALSE&utm_campaign=543',
                 'http://example.com/?utm_source=XYZ&utm_medium=FALSE&utm_campaign=543'
             )

--- a/tests/test-redirects.php
+++ b/tests/test-redirects.php
@@ -77,7 +77,7 @@ class WpcomLegacyRedirectsTest extends WP_UnitTestCase {
                 // The plugin should strip the hash and only store the URL path.
                 '/hash-redirectA/#with-hash',
                 'http://example.com/',
-                '/hash-redirectA/#with-hash?utm_source=SDF',
+                '/hash-redirectA/?utm_source=SDF#with-hash',
                 'http://example.com/?utm_source=SDF'
             ),
 

--- a/tests/test-redirects.php
+++ b/tests/test-redirects.php
@@ -57,43 +57,43 @@ class WpcomLegacyRedirectsTest extends WP_UnitTestCase {
 	}
 
 
-    /**
-     * Data Provider of Redirect Rules and test urls for Protected Params
-     *
-     * @return array
-     */
-    public function get_protected_redirect_data() {
-        return array(
-            'redirect_simple_protected' => array(
-                '/simple-redirectA/',
-                'http://example.com/',
-                '/simple-redirectA/?utm_source=XYZ',
-                'http://example.com/?utm_source=XYZ'
-            ),
+	/**
+	 * Data Provider of Redirect Rules and test urls for Protected Params
+	 *
+	 * @return array
+	 */
+ 	public function get_protected_redirect_data() {
+		return array(
+			'redirect_simple_protected' => array(
+ 				'/simple-redirectA/',
+ 				'http://example.com/',
+ 				'/simple-redirectA/?utm_source=XYZ',
+				'http://example.com/?utm_source=XYZ'
+			),
 
-            'redirect_protected_with_querystring' => array(
-                '/b-redirect/?with=query-string',
-                'http://example.com/',
-                '/b-redirect/?with=query-string&utm_medium=123',
-                'http://example.com/?utm_medium=123'
-            ),
+			'redirect_protected_with_querystring' => array(
+				'/b-redirect/?with=query-string',
+				'http://example.com/',
+				'/b-redirect/?with=query-string&utm_medium=123',
+				'http://example.com/?utm_medium=123'
+			),
 
-            'redirect_protected_with_hashes' => array(
-                // The plugin should strip the hash and only store the URL path.
-                '/hash-redirectA/#with-hash',
-                'http://example.com/',
-                '/hash-redirectA/?utm_source=SDF#with-hash',
-                'http://example.com/?utm_source=SDF'
-            ),
+			'redirect_protected_with_hashes' => array(
+				// The plugin should strip the hash and only store the URL path.
+				'/hash-redirectA/#with-hash',
+				'http://example.com/',
+				'/hash-redirectA/?utm_source=SDF#with-hash',
+ 				'http://example.com/?utm_source=SDF'
+			),
 
-            'redirect_multiple_protected' => array(
-                '/simple-redirectC/',
-                'http://example.com/',
-                '/simple-redirectC/?utm_source=XYZ&utm_medium=FALSE&utm_campaign=543',
-                'http://example.com/?utm_source=XYZ&utm_medium=FALSE&utm_campaign=543'
-            )
-        );
-    }
+			'redirect_multiple_protected' => array(
+				'/simple-redirectC/',
+				'http://example.com/',
+				'/simple-redirectC/?utm_source=XYZ&utm_medium=FALSE&utm_campaign=543',
+				'http://example.com/?utm_source=XYZ&utm_medium=FALSE&utm_campaign=543'
+			)
+		);
+	}
 
 	/**
 	 * Verify that whitelisted parameters are maintained on final redirect urls.
@@ -101,19 +101,21 @@ class WpcomLegacyRedirectsTest extends WP_UnitTestCase {
 	 * @dataProvider get_protected_redirect_data
 	 */
 	function test_protected_query_redirect( $from, $to, $protected_from, $protected_to ) {
-        add_filter( 'wpcom_legacy_redirector_preserve_query_params', function( $preserved_params ){
-            array_push( $preserved_params,
-                'utm_source',
-                'utm_medium',
-                'utm_campaign'
-            );
-            return $preserved_params;
-        } );
+		add_filter( 'wpcom_legacy_redirector_preserve_query_params', function( $preserved_params ){
+ 			array_push( $preserved_params,
+				'utm_source',
+				'utm_medium',
+				'utm_campaign'
+			);
+			return $preserved_params;
+		} );
 
-        $redirect = WPCOM_Legacy_Redirector::insert_legacy_redirect( $from, $to );
-        $this->assertTrue( $redirect, 'insert_legacy_redirect failed' );
+		$redirect = WPCOM_Legacy_Redirector::insert_legacy_redirect( $from, $to );
+		$this->assertTrue( $redirect, 'insert_legacy_redirect failed' );
 
-        $redirect = WPCOM_Legacy_Redirector::get_redirect_uri( $protected_from );
-        $this->assertEquals( $redirect, $protected_to, 'get_redirect_uri failed' );
-    }
+		$redirect = WPCOM_Legacy_Redirector::get_redirect_uri( $protected_from );
+		$this->assertEquals( $redirect, $protected_to, 'get_redirect_uri failed' );
+	}
+
 }
+

--- a/tests/test-redirects.php
+++ b/tests/test-redirects.php
@@ -57,6 +57,11 @@ class WpcomLegacyRedirectsTest extends WP_UnitTestCase {
 	}
 
 
+    /**
+     * Data Provider of Redirect Rules and test urls for Protected Params
+     *
+     * @return array
+     */
     public function get_protected_redirect_data() {
         return array(
             'redirect_simple_protected' => array(
@@ -91,6 +96,8 @@ class WpcomLegacyRedirectsTest extends WP_UnitTestCase {
     }
 
     /**
+     * Verify that whitelisted parameters are maintained on final redirect urls.
+     *
      * @dataProvider get_protected_redirect_data
      */
 	function test_protected_query_redirect( $from, $to, $protected_from, $protected_to ) {

--- a/tests/test-redirects.php
+++ b/tests/test-redirects.php
@@ -95,11 +95,11 @@ class WpcomLegacyRedirectsTest extends WP_UnitTestCase {
         );
     }
 
-    /**
-     * Verify that whitelisted parameters are maintained on final redirect urls.
-     *
-     * @dataProvider get_protected_redirect_data
-     */
+	/**
+	 * Verify that whitelisted parameters are maintained on final redirect urls.
+	 *
+	 * @dataProvider get_protected_redirect_data
+	 */
 	function test_protected_query_redirect( $from, $to, $protected_from, $protected_to ) {
         add_filter( 'wpcom_legacy_redirector_preserve_query_params', function( $preserved_params ){
             array_push( $preserved_params,

--- a/tests/test-redirects.php
+++ b/tests/test-redirects.php
@@ -62,7 +62,7 @@ class WpcomLegacyRedirectsTest extends WP_UnitTestCase {
             'redirect_simple_protected' => array(
                 '/simple-redirectA',
                 'http://example.com',
-                'simple-redirect/?utm_source=XYZ',
+                '/simple-redirectA/?utm_source=XYZ',
                 'http://example.com/?utm_source=XYZ'
             ),
 
@@ -84,7 +84,7 @@ class WpcomLegacyRedirectsTest extends WP_UnitTestCase {
             'redirect_multiple_protected' => array(
                 '/simple-redirectC',
                 'http://example.com',
-                'simple-redirectC/?utm_source=XYZ&utm_medium=FALSE&utm_campaign=543',
+                '/simple-redirectC/?utm_source=XYZ&utm_medium=FALSE&utm_campaign=543',
                 'http://example.com/?utm_source=XYZ&utm_medium=FALSE&utm_campaign=543'
             )
         );
@@ -94,6 +94,15 @@ class WpcomLegacyRedirectsTest extends WP_UnitTestCase {
      * @dataProvider get_protected_redirect_data
      */
 	function test_protected_query_redirect( $from, $to, $protected_from, $protected_to ) {
+        add_filter( 'wpcom_legacy_redirector_preserve_query_params', function( $preserved_params ){
+            array_push( $preserved_params,
+                'utm_source',
+                'utm_medium',
+                'utm_campaign'
+            );
+            return $preserved_params;
+        } );
+
         $redirect = WPCOM_Legacy_Redirector::insert_legacy_redirect( $from, $to );
         $this->assertTrue( $redirect, 'insert_legacy_redirect failed' );
 

--- a/wpcom-legacy-redirector.php
+++ b/wpcom-legacy-redirector.php
@@ -126,16 +126,16 @@ class WPCOM_Legacy_Redirector {
 		$components = wp_parse_url( $url );
 		if ( isset( $components['query'] ) ) { // Verify Query Params exist.
 
-            // Parse Query String to Associated Array.
-            parse_str($components['query'], $param_values);
-            // For every white listed param save value and strip from url
-            foreach ($protected_params as $protected_param) {
-                if (!empty($param_values[$protected_param])) {
-                    $protected_param_values[$protected_param] = $param_values[$protected_param];
-                    $url = remove_query_arg($protected_param, $url);
-                }
-            }
-        }
+			// Parse Query String to Associated Array.
+			parse_str($components['query'], $param_values);
+ 			// For every white listed param save value and strip from url
+			foreach ($protected_params as $protected_param) {
+				if (!empty($param_values[$protected_param])) {
+					$protected_param_values[$protected_param] = $param_values[$protected_param];
+					$url = remove_query_arg($protected_param, $url);
+				}
+			}
+		}
 
 		$url_hash = self::get_url_hash( $url );
 

--- a/wpcom-legacy-redirector.php
+++ b/wpcom-legacy-redirector.php
@@ -118,19 +118,25 @@ class WPCOM_Legacy_Redirector {
 		}
 
 		// White list of Params that should be pass through as is.
-        $protected_params = apply_filters( 'wpcom_legacy_redirector_preserve_query_params', array(), $url );
+		$protected_params = apply_filters( 'wpcom_legacy_redirector_preserve_query_params', array(), $url );
 		$protected_param_values = array();
 		$param_values = array();
-        $components = wp_parse_url( $url );
-		if ( isset( $components['query'] ) ) {
-            parse_str($components['query'] , $param_values);
+
+		// Parse URL to get Query Params.
+		$components = wp_parse_url( $url );
+		if ( isset( $components['query'] ) ) { // Verify Query Params exist.
+
+            // Parse Query String to Associated Array.
+            parse_str($components['query'], $param_values);
+            // For every white listed param save value and strip from url
             foreach ($protected_params as $protected_param) {
-                if( ! empty( $param_values[$protected_param] ) ) {
+                if (!empty($param_values[$protected_param])) {
                     $protected_param_values[$protected_param] = $param_values[$protected_param];
                     $url = remove_query_arg($protected_param, $url);
                 }
             }
         }
+
 		$url_hash = self::get_url_hash( $url );
 
 		$redirect_post_id = wp_cache_get( $url_hash, self::CACHE_GROUP );
@@ -140,7 +146,7 @@ class WPCOM_Legacy_Redirector {
 			wp_cache_add( $url_hash, $redirect_post_id, self::CACHE_GROUP );
 		}
 
-        if ( $redirect_post_id ) {
+		if ( $redirect_post_id ) {
 			$redirect_post = get_post( $redirect_post_id );
 			if ( ! $redirect_post instanceof WP_Post ) {
 				// If redirect post object doesn't exist, reset cache
@@ -148,12 +154,13 @@ class WPCOM_Legacy_Redirector {
 
 				return false;
 			} elseif ( 0 !== $redirect_post->post_parent ) {
-				return add_query_arg( $protected_param_values, get_permalink( $redirect_post->post_parent ) );
+				return add_query_arg( $protected_param_values, get_permalink( $redirect_post->post_parent ) ); // Add Whitelisted Params to the Redirect URL.
 			} elseif ( ! empty( $redirect_post->post_excerpt ) ) {
-				return add_query_arg( $protected_param_values, esc_url_raw( $redirect_post->post_excerpt ) );
+				return add_query_arg( $protected_param_values, esc_url_raw( $redirect_post->post_excerpt ) ); // Add Whitelisted Params to the Redirect URL
 			}
 		}
-        return false;
+
+		return false;
 	}
 
 	static function get_redirect_post_id( $url ) {

--- a/wpcom-legacy-redirector.php
+++ b/wpcom-legacy-redirector.php
@@ -125,8 +125,10 @@ class WPCOM_Legacy_Redirector {
 		if ( isset( $components['query'] ) ) {
             parse_str($components['query'] , $param_values);
             foreach ($protected_params as $protected_param) {
-                $protected_param_values[$protected_param] = $param_values[$protected_param];
-                $url = remove_query_arg($protected_param, $url);
+                if( ! empty( $param_values[$protected_param] ) ) {
+                    $protected_param_values[$protected_param] = $param_values[$protected_param];
+                    $url = remove_query_arg($protected_param, $url);
+                }
             }
         }
 		$url_hash = self::get_url_hash( $url );

--- a/wpcom-legacy-redirector.php
+++ b/wpcom-legacy-redirector.php
@@ -123,11 +123,11 @@ class WPCOM_Legacy_Redirector {
 		$param_values = array();
 
 		// Parse URL to get Query Params.
-		$components = wp_parse_url( $url );
-		if ( isset( $components['query'] ) ) { // Verify Query Params exist.
+		$query_params = wp_parse_url( $url, PHP_URL_QUERY );
+		if ( ! empty( $query_params ) ) { // Verify Query Params exist.
 
 			// Parse Query String to Associated Array.
-			parse_str($components['query'], $param_values);
+			parse_str($query_params, $param_values);
  			// For every white listed param save value and strip from url
 			foreach ($protected_params as $protected_param) {
 				if (!empty($param_values[$protected_param])) {

--- a/wpcom-legacy-redirector.php
+++ b/wpcom-legacy-redirector.php
@@ -121,10 +121,13 @@ class WPCOM_Legacy_Redirector {
         $protected_params = apply_filters( 'wpcom_legacy_redirector_preserve_query_params', array(), $url );
 		$protected_param_values = array();
 		$param_values = array();
-        parse_str( $_SERVER['QUERY_STRING'], $param_values );
-        foreach( $protected_params as $protected_param ) {
-            $protected_param_values[ $protected_param ] = $param_values[ $protected_param ];
-            $url = remove_query_arg( $protected_param, $url );
+        $components = wp_parse_url( $url );
+		if ( isset( $components['query'] ) ) {
+            parse_str($components['query'] , $param_values);
+            foreach ($protected_params as $protected_param) {
+                $protected_param_values[$protected_param] = $param_values[$protected_param];
+                $url = remove_query_arg($protected_param, $url);
+            }
         }
 		$url_hash = self::get_url_hash( $url );
 


### PR DESCRIPTION
Resolution for Issue #20 
… allow for the whitelisting of params that should be passed through to the redirected url.

Usage:
```
add_filter( 'wpcom_legacy_redirector_preserve_query_params', function( $preserved_params ){
    array_push( $preserved_params,
        'utm_source',
        'utm_medium',
        'utm_campaign'
    );
    return $preserved_params;
} );
```

Case :
`test.org/legacy_page/?utm_source=PAID_AD` would redirect to `test.org/new_uri/?utm_source=PAID_AD`
`test.org/legaccy_page/?utm_source=BLUE` would redirect to `test.org/new_uri/?utm_source=BLUE`