### PR TITLE
Ditch wp_safe_redirect

### DIFF
--- a/wpcom-legacy-redirector.php
+++ b/wpcom-legacy-redirector.php
@@ -59,7 +59,8 @@ class WPCOM_Legacy_Redirector {
 			if ( $redirect_uri ) {
 				header( 'X-legacy-redirect: HIT' );
 				$redirect_status = apply_filters( 'wpcom_legacy_redirector_redirect_status', 301, $url );
-				wp_safe_redirect( $redirect_uri, $redirect_status );
+				// No "safe" redirect here since the plugin allows external redirects
+				wp_redirect( $redirect_uri, $redirect_status );
 				exit;
 			}
 		}


### PR DESCRIPTION
The plugin allows external redirects so we don't need the added validation that wp_safe_redirect provides.

This avoids the need to explicitly filter `allowed_redirect_hosts`.