### PR TITLE
Use precise distribution for PHP 5.3 testing with Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,15 @@ php:
   - 5.3
   - 5.6
 
+dist: trusty
+
 env:
   - WP_VERSION=latest WP_MULTISITE=0
 
 matrix:
   include:
     - php: 5.3
+      dist: precise
       env: WP_VERSION=latest WP_MULTISITE=1
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,20 +5,18 @@ notifications:
     on_success: never
     on_failure: change
 
-php:
-  - 5.3
-  - 5.6
-
-dist: trusty
-
 env:
   - WP_VERSION=latest WP_MULTISITE=0
+
+dist: trusty
 
 matrix:
   include:
     - php: 5.3
       dist: precise
-      env: WP_VERSION=latest WP_MULTISITE=1
+    - php: 5.6
+    - env: WP_VERSION=latest WP_MULTISITE=0
+    - env: WP_VERSION=latest WP_MULTISITE=1
 
 before_script:
   - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION


### PR DESCRIPTION
Travis does not support testing PHP 5.3 on Trusty. While Trusty isn't specified in the travis.yml file, it's being automatically selected in Travis and needs to be explicitly overridden.

Documentation from Travis: https://docs.travis-ci.com/user/reference/trusty/#PHP-images
Where Trust support was removed: https://github.com/travis-ci/travis-ci/issues/2963

Similar changes were made in Jetpack with:
https://github.com/Automattic/jetpack/commit/963e3d5db9ef215c649a796062d5a2190f433f6c#diff-354f30a63fb0907d4ad57269548329e3
https://github.com/Automattic/jetpack/commit/5ab75dfce1718c60950580632db6a2b9b01b9547#diff-354f30a63fb0907d4ad57269548329e3

cc @mjangda 