### PR TITLE
fixes plugin redirecting removed redirect

### DIFF
--- a/wpcom-legacy-redirector.php
+++ b/wpcom-legacy-redirector.php
@@ -170,7 +170,7 @@ class WPCOM_Legacy_Redirector {
 
 		$url_hash = self::get_url_hash( $url );
 
-		$redirect_post_id = $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE post_type = %s AND post_name = %s LIMIT 1", self::POST_TYPE, $url_hash ) );
+		$redirect_post_id = $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE post_type = %s AND post_name = %s AND post_status = %s LIMIT 1", self::POST_TYPE, $url_hash, 'publish' ) );
 
 		if ( ! $redirect_post_id ) {
 			$redirect_post_id = 0;


### PR DESCRIPTION
fixed issue #29 since the plugin uses raw SQL to get redirects, removed redirects are also queried, adds post_status constraint and set it to publish 

I'm bitween only allowing publish or removing trash and draft ans private from the query, depends more on the business logic and use case