### PR TITLE
UI: Show absolute URLs as relative URLs

### DIFF
--- a/includes/class-wpcom-legacy-redirector-ui.php
+++ b/includes/class-wpcom-legacy-redirector-ui.php
@@ -101,6 +101,8 @@ class WPCOM_Legacy_Redirector_UI {
 					// Check if it's the Home URL
 					if ( true === WPCOM_Legacy_Redirector::check_if_excerpt_is_home( $excerpt ) ) {
 						echo esc_html( $excerpt );
+					} elseif ( 0 === strpos( $excerpt, get_option( 'home' ) ) ) {
+						echo esc_html( str_replace( get_option( 'home' ), '', $excerpt ) );
 					} elseif ( 0 === strpos( $excerpt, 'http' ) ) {
 						echo esc_url_raw( $excerpt );
 					} else {


### PR DESCRIPTION
If the start of the To URL matches the `home` value, then strip it off. This creates a more consistent view, and allows absolute URLs to stand out more. This can also be useful for spotting differences in protocol between the current site and the redirect destination.

Here's a screenshot from my local `http` system:

<img width="757" alt="Screenshot 2019-05-27 at 14 25 33" src="https://user-images.githubusercontent.com/88371/58422757-54060180-808b-11e9-84bf-010bcb4fcd32.png">

Here's the same system with a https setup:

<img width="780" alt="Screenshot 2019-05-27 at 14 27 11" src="https://user-images.githubusercontent.com/88371/58422916-b3fca800-808b-11e9-8f59-e4bedd613bca.png">


Fixes #44.