### PR TITLE
404 check: allow self-signed certificate to pass

### DIFF
--- a/includes/class-wpcom-legacy-redirector.php
+++ b/includes/class-wpcom-legacy-redirector.php
@@ -355,6 +355,13 @@ class WPCOM_Legacy_Redirector {
 			$response = vip_safe_wp_remote_get( $url );
 		} else {
 			$response = wp_remote_get( $url );
+			// If it was an error, try again with no SSL verification, in case it was a self-signed certificate: https://github.com/Automattic/WPCOM-Legacy-Redirector/issues/64
+			if ( is_wp_error( $response ) ) {
+				$args = [
+					'sslverify' => false,
+				];
+				$response = wp_remote_get( $url, $args );
+			}
 		}
 		$response_code = '';
 		if ( is_array( $response ) ) {


### PR DESCRIPTION
When adding a redirect on a https setup, a self-signed certificate will stop cURL from completing its check that the From URL results in a 404 Not Found.

We check for this error and allow this to pass.

Fixes #64.

Open to other approaches if this is deemed an unsuitable fix.