### PR TITLE
x_redirect_by support in lieu of custom header

### DIFF
--- a/includes/class-wpcom-legacy-redirector.php
+++ b/includes/class-wpcom-legacy-redirector.php
@@ -85,7 +85,7 @@ class WPCOM_Legacy_Redirector {
 
 				// Third argument introduced to support the x_redirect_by header to denote WP redirect source.
 				if ( version_compare( get_bloginfo( 'version' ), '5.1.0', '>=' ) ) {
-					wp_safe_redirect( $redirect_uri, $redirect_status, self::POST_TYPE );
+					wp_safe_redirect( $redirect_uri, $redirect_status, WPCOM_LEGACY_REDIRECTOR_PLUGIN_NAME );
 				} else {
 					header( 'X-legacy-redirect: HIT' );
 					wp_safe_redirect( $redirect_uri, $redirect_status );

--- a/includes/class-wpcom-legacy-redirector.php
+++ b/includes/class-wpcom-legacy-redirector.php
@@ -81,9 +81,16 @@ class WPCOM_Legacy_Redirector {
 		if ( $request_path ) {
 			$redirect_uri = self::get_redirect_uri( $request_path );
 			if ( $redirect_uri ) {
-				header( 'X-legacy-redirect: HIT' );
 				$redirect_status = apply_filters( 'wpcom_legacy_redirector_redirect_status', 301, $url );
-				wp_safe_redirect( $redirect_uri, $redirect_status );
+
+				// Third argument introduced to support the x_redirect_by header to denote WP redirect source.
+				if ( version_compare( get_bloginfo( 'version' ), '5.1.0', '>=' ) ) {
+					wp_safe_redirect( $redirect_uri, $redirect_status, self::POST_TYPE );
+				} else {
+					header( 'X-legacy-redirect: HIT' );
+					wp_safe_redirect( $redirect_uri, $redirect_status );
+				}
+
 				exit;
 			}
 		}

--- a/wpcom-legacy-redirector.php
+++ b/wpcom-legacy-redirector.php
@@ -22,6 +22,7 @@
  */
 
 define( 'WPCOM_LEGACY_REDIRECTOR_VERSION', '1.4.0-alpha' );
+define( 'WPCOM_LEGACY_REDIRECTOR_PLUGIN_NAME', 'WPCOM Legacy Redirector' );
 
 if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	require __DIR__ . '/includes/class-wpcom-legacy-redirector-cli.php';


### PR DESCRIPTION
The `x_redirect_by` header is added automatically since WP 5.1.0 to calls to `wp_safe_redirect()`. This change sets the default from "WordPress" to "WPCOM Legacy Redirector" using the new third argument. This also retires the additional custom header - `X-Legacy-Redirect: HIT`.

Earlier WP versions, before the "x_redirect_by" argument was added, will still utilize the custom header as it always has been.

Issue #51 

Header Before WP 5.1.0: 
`X-Legacy-Redirect: HIT`

Header for WP 5.1.0+ :
`X-Redirect-By: WordPress`
`X-Legacy-Redirect: HIT`

Header for WP 5.1.0+ (After this PR) :
`X-Redirect-By: WPCOM Legacy Redirector`

_**Please advise if any WPCOM logging tools or infrastructure applications (such as Varnish/Nginx) is currently referencing the old header. That's the most likely explanation for the cache type header value of "HIT".**_