### PR TITLE
Refresh build configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 language: php
+os: linux
+dist: xenial
+
+services:
+  - mysql
 
 notifications:
   email:
@@ -9,12 +14,35 @@ php:
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
+  - 7.3
+  - 7.4
+  - 8.0
+  - "nightly"
 
 env:
   - WP_VERSION=latest WP_MULTISITE=0
   - WP_VERSION=latest WP_MULTISITE=1
 
-before_script:
+jobs:
+  allow_failures:
+    - php: "nightly"
+
+before_install:
+  # Speed up build time by disabling Xdebug.
+  # https://johnblackbourn.com/reducing-travis-ci-build-times-for-wordpress-projects/
+  # https://twitter.com/kelunik/status/954242454676475904
+  - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
+
+install:
+  - |
+    if [[ $TRAVIS_PHP_VERSION == "nightly" || $TRAVIS_PHP_VERSION == "8.0" ]]; then
+      # PHPUnit 7.x does not allow for installation on PHP 8, so ignore platform
+      # requirements to get PHPUnit 7.x to install on nightly.
+      travis_retry composer update --ignore-platform-reqs
+    else
+      travis_retry composer update
+    fi
   - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
 
-script: phpunit
+script: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,9 @@
   "require": {
     "composer/installers": "^1.0"
   },
+  "require-dev": {
+    "phpunit/phpunit": "^4 || ^5 || ^6 || ^7"
+  },
   "support": {
     "issues": "https://github.com/Automattic/WPCOM-Legacy-Redirector/issues",
     "source": "https://github.com/Automattic/WPCOM-Legacy-Redirector"


### PR DESCRIPTION
The default build environment for Travis has changed since the last time Travis was run, as has the available versions of PHP, so this PR refreshes all of that.

- Add PHPUnit as a dev dependency in `composer.json`.
- Use [Xenial build environment](https://docs.travis-ci.com/user/reference/xenial/) which has PHP 5.6, 7.1 and 7.2 installed by default. Other versions are installed at run-time.
- Add `mysql` service to allow WP integration tests setup the DB and run.
- Expand the range of tested versions of PHP, including nightly, which is allowed to fail.
- Disable Xdebug to speed up build.
- Allow PHPUnit 7 to be installed on PHP 8 bu ignoring the platform requirements.
- Use the Composer-installed version of PHPUnit rather than the built-in version.

This should be reviewed and merged before other PRs are done, so that they have a chance of passing the build. Existing PRs should be rebased on to `develop` once this has been merged.