### PR TITLE
Add .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+/vendor/
+/composer.lock
+/.phpcs.xml
+/phpcs.xml
+/phpunit.xml
+/.phpunit.result.cache


### PR DESCRIPTION
Pre-emptively including PHPCS and PHPUnit related files.

The correct config files to use are `.phpcs.xml.dist` and `phpunit.xml.dist` - the non `.dist` files (ignored here) can be used for local overrides.

Other files directories like `.idea`, should be in a contributor's global gitignore.