### PR TITLE
Bugfix/73 admin redirect save fix

### DIFF
--- a/includes/class-lookup.php
+++ b/includes/class-lookup.php
@@ -52,7 +52,14 @@ final class Lookup {
 				return add_query_arg( $preservable_params, get_permalink( $redirect_post->post_parent ) );
 			} elseif ( ! empty( $redirect_post->post_excerpt ) ) {
 				// Add preserved params to the destination URL.
-				return add_query_arg( $preservable_params, esc_url_raw( $redirect_post->post_excerpt ) );
+				// We need to add here the home_url() if the target starts with /.
+				$redirect_url = esc_url_raw( $redirect_post->post_excerpt );
+
+				if ( strpos( $redirect_post->post_excerpt, '/' ) === 0 ) {
+					$redirect_url = home_url() . $redirect_url;
+				}
+
+				return add_query_arg( $preservable_params, $redirect_url );
 			}
 		}
 		return false;

--- a/includes/class-utils.php
+++ b/includes/class-utils.php
@@ -51,4 +51,20 @@ final class Utils {
 
 		return $parts;
 	}
+
+	/**
+	 * Get WP Home URL without path suffix.
+	 *
+	 * @return string
+	 */
+	public static function get_home_domain_without_path() {
+		$home_url_info = self::mb_parse_url( home_url() );
+		$return_url    = $home_url_info['scheme'] . '://' . $home_url_info['host'];
+
+		if ( !empty( $home_url_info['port'] ) ) {
+			$return_url .= ':' . $home_url_info['port'];
+		}
+
+		return $return_url;
+	}
 }

--- a/includes/class-wpcom-legacy-redirector-ui.php
+++ b/includes/class-wpcom-legacy-redirector-ui.php
@@ -7,6 +7,7 @@
 
 use Automattic\LegacyRedirector\Capability;
 use Automattic\LegacyRedirector\Post_Type;
+use Automattic\LegacyRedirector\Utils;
 
 /**
  * User interface additions.
@@ -154,11 +155,20 @@ class WPCOM_Legacy_Redirector_UI {
 				);
 			} else {
 				$redirect_from = sanitize_text_field( $_POST['redirect_from'] );
+
+				// We apply the home_url() prefix to $redirect_from.
+				$redirect_url_info = Utils::mb_parse_url( home_url() . $redirect_from);
+				$redirect_from = $redirect_url_info['path'];
+				if( !empty( $redirect_url_info['query'] ) ) {
+					$redirect_from .= '?' . $redirect_url_info['query'];
+				}
+
 				$redirect_to   = sanitize_text_field( $_POST['redirect_to'] );
 				if ( WPCOM_Legacy_Redirector::validate( $redirect_from, $redirect_to ) ) {
 					$output = WPCOM_Legacy_Redirector::insert_legacy_redirect( $redirect_from, $redirect_to, true );
 					if ( true === $output ) {
-						$link       = '<a href="' . esc_url( $redirect_from ) . '" target="_blank">' . esc_url( $redirect_from ) . '</a>';
+						$follow_home_domain = Utils::get_home_domain_without_path();
+						$link       = '<a href="' . esc_url( $follow_home_domain . $redirect_from ) . '" target="_blank">' . esc_html( $redirect_from ) . '</a>';
 						$messages[] = __( 'The redirect was added successfully. Check Redirect: ', 'wpcom-legacy-redirector' ) . $link;
 					} elseif ( is_wp_error( $output ) ) {
 						foreach ( $output->get_error_messages() as $error ) {

--- a/includes/class-wpcom-legacy-redirector.php
+++ b/includes/class-wpcom-legacy-redirector.php
@@ -108,7 +108,7 @@ class WPCOM_Legacy_Redirector {
 		}
 
 		wp_enqueue_script( 'wpcom-legacy-redirector', plugins_url( '/../js/admin-add-redirects.js', __FILE__ ), array(), WPCOM_LEGACY_REDIRECTOR_VERSION, true );
-		wp_localize_script( 'wpcom-legacy-redirector', 'wpcomLegacyRedirector', array( 'siteurl' => get_option( 'siteurl' ) ) );
+		wp_localize_script( 'wpcom-legacy-redirector', 'wpcomLegacyRedirector', array( 'siteurl' => home_url() ) );
 	}
 
 	/**

--- a/tests/Integration/LookupTest.php
+++ b/tests/Integration/LookupTest.php
@@ -41,17 +41,17 @@ final class LookupTest extends TestCase {
 		return array(
 			'redirect unicode characters with querystring' => array(
 				'/فوتوغرافيا/?test=فوتوغرافيا',
-				'/some_other_page',
+				'http://example.com/some_other_page',
 				'301',
 			),
 			'redirect_simple'                              => array(
 				'/test',
-				'/',
+				'http://example.com/',
 				'301',
 			),
 			'redirect_unicode_no_query'                    => array(
 				'/فوتوغرافيا/',
-				'/',
+				'http://example.com/',
 				'301',
 			),
 		);

--- a/tests/Integration/RedirectsTest.php
+++ b/tests/Integration/RedirectsTest.php
@@ -26,6 +26,12 @@ final class RedirectsTest extends TestCase {
 	 */
 	public function get_redirect_data() {
 		return array(
+			'redirect_relative_path'  => array(
+				'/non-existing-page',
+				'/test2',
+				home_url() . '/test2',
+			),
+
 			'redirect_unicode_in_path'  => array(
 				// https://www.w3.org/International/articles/idn-and-iri/ .
 				'/JP納豆',
@@ -64,12 +70,16 @@ final class RedirectsTest extends TestCase {
 	 * @param string $from From path.
 	 * @param string $to   Destination.
 	 */
-	public function test_redirect_is_inserted_successfully_and_returns_true( $from, $to ) {
+	public function test_redirect_is_inserted_successfully_and_returns_true( $from, $to, $expected = null ) {
 		$redirect = WPCOM_Legacy_Redirector::insert_legacy_redirect( $from, $to, false );
 		$this->assertTrue( $redirect, 'insert_legacy_redirect() and return true, failed' );
 
 		$redirect = Lookup::get_redirect_uri( $from );
-		$this->assertEquals( $redirect, $to, 'get_redirect_uri(), failed - got "' . $redirect . '", expected "' . $to . '"' );
+
+		if ( \is_null( $expected ) ) {
+			$expected = $to;
+		}
+		$this->assertEquals( $expected, $redirect, 'get_redirect_uri(), failed - got "' . $redirect . '", expected "' . $to . '"' );
 	}
 
 	/**


### PR DESCRIPTION
This PR fixes the UI relative path issues mentioned in #73 

Committed changes:

- the fix makes use of the home_url() function to compute the absolute path we should save in the database for backward compatibility, so users don't need to add the path prefix for multisites anymore in the UI
- added Follow link in backend for easier testing
- fixed the redirection  target URL, so when a relative path is provided, the home_url() is prefixed to it, added unit test as well