### PR TITLE
Bugfix/77 wpcom vip add role caps fix

### DIFF
--- a/includes/class-capability.php
+++ b/includes/class-capability.php
@@ -5,10 +5,21 @@ namespace Automattic\LegacyRedirector;
 final class Capability {
 	const MANAGE_REDIRECTS_CAPABILITY = 'manage_redirects';
 
+	// Used to flip the version of the available roles capabilities.
+	const CAPABILITIES_VER = 1;
+
 	/**
 	 * Add custom capability onto some existing roles using VIP Helpers with fallbacks.
 	 */
 	public function register() {
+
+		$capabilities_version_key = $this->get_capabilities_version_key();
+
+		// We disable capabilities register unless there is a version increment.
+		if ( self::CAPABILITIES_VER <= get_option( $capabilities_version_key, 0 ) ) {
+			return false;
+		}
+
 		if ( function_exists( 'wpcom_vip_add_role_caps' ) ) {
 			wpcom_vip_add_role_caps( 'administrator', self::MANAGE_REDIRECTS_CAPABILITY );
 			wpcom_vip_add_role_caps( 'editor', self::MANAGE_REDIRECTS_CAPABILITY );
@@ -19,5 +30,43 @@ final class Capability {
 				$role_obj->add_cap( self::MANAGE_REDIRECTS_CAPABILITY );
 			}
 		}
+
+		update_option( $capabilities_version_key, self::CAPABILITIES_VER );
+
+		return true;
+	}
+
+	/**
+	 * Unregister the capabilities
+	 *
+	 * @return void
+	 */
+	public function unregister() {
+
+		$capabilities_version_key = $this->get_capabilities_version_key();
+
+		if ( function_exists( 'wpcom_vip_remove_role_caps' ) ) {
+			wpcom_vip_remove_role_caps( 'administrator', self::MANAGE_REDIRECTS_CAPABILITY );
+			wpcom_vip_remove_role_caps( 'editor', self::MANAGE_REDIRECTS_CAPABILITY );
+		} else {
+			$roles = array( 'administrator', 'editor' );
+			foreach ( $roles as $role ) {
+				$role_obj = get_role( $role );
+				$role_obj->remove_cap( self::MANAGE_REDIRECTS_CAPABILITY );
+			}
+		}
+
+		delete_option( $capabilities_version_key, self::CAPABILITIES_VER );
+
+		return true;
+	}
+
+	/**
+	 * Gets capabilities version key
+	 *
+	 * @return string
+	 */
+	private function get_capabilities_version_key() {
+		return self::MANAGE_REDIRECTS_CAPABILITY . '_capability_version';
 	}
 }

--- a/includes/class-wpcom-legacy-redirector.php
+++ b/includes/class-wpcom-legacy-redirector.php
@@ -18,10 +18,19 @@ class WPCOM_Legacy_Redirector {
 	 */
 	static function start() {
 		add_action( 'init', array( __CLASS__, 'init' ) );
+		add_action( 'admin_init', array( __CLASS__, 'admin_init' ) );
 		add_filter( 'template_redirect', array( __CLASS__, 'maybe_do_redirect' ), 0 ); // hook in early, before the canonical redirect.
 		add_action( 'admin_menu', array( new WPCOM_Legacy_Redirector_UI(), 'admin_menu' ) );
 		add_filter( 'admin_enqueue_scripts', array( __CLASS__, 'wpcom_legacy_add_redirect_js' ) );
 		add_filter( 'bulk_actions-edit-' . Post_Type::POST_TYPE, array( __CLASS__, 'remove_bulk_edit' ) );
+	}
+
+	/**
+	 * Initialize and register other classes during admin_init hook.
+	 */
+	static function admin_init() {
+		$capability = new Capability();
+		$capability->register();
 	}
 
 	/**
@@ -30,9 +39,6 @@ class WPCOM_Legacy_Redirector {
 	static function init() {
 		$post_type = new Post_Type();
 		$post_type->register();
-
-		$capability = new Capability();
-		$capability->register();
 
 		$list_redirects = new List_Redirects();
 		$list_redirects->init();

--- a/tests/integration/CapabilityTest.php
+++ b/tests/integration/CapabilityTest.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Automattic\LegacyRedirector\Tests;
+
+use Automattic\LegacyRedirector\Capability;
+use WP_User;
+
+/**
+ * CapabilityTest class.
+ */
+final class CapabilityTest extends TestCase {
+
+	/**
+	 * tearDown method to be called after each test.
+	 *
+	 * @return void
+	 */
+	public function tearDown() {
+
+		(new Capability())->unregister();
+	}
+
+	/**
+	 * Test capabilities for Capability::MANAGE_REDIRECTS_CAPABILITY.
+	 *
+	 * @return void
+	 */
+	public function test_new_admin_capability() {
+
+		$capability = new Capability();
+
+		// We need to force clear capabilities here as the wp_options `roles` option might not get cleared after a failed test.
+		$capability->unregister();
+
+		// in WP_User class, if multisite and user is administrator, all capabilities are allowed, so this test is not useful.
+		if ( ! is_multisite() ) {
+			// We check if a new admin user does not have the redirect capability.
+			$user_id = 1;
+			$this->assertUserNotHasRedirectCapability( $user_id );
+		}
+
+		$this->assertRoleNotHasRedirectsCapability( 'administrator' );
+		$this->assertRoleNotHasRedirectsCapability( 'editor' );
+		$this->assertRoleNotHasRedirectsCapability( 'subscriber' );
+		$this->assertRoleNotHasRedirectsCapability( '' );
+
+		$capability->register();
+
+		$this->assertRoleHasRedirectsCapability( 'administrator' );
+		$this->assertRoleHasRedirectsCapability( 'editor' );
+		$this->assertRoleNotHasRedirectsCapability( 'subscriber' ); // Should be no change.
+		$this->assertRoleNotHasRedirectsCapability( '' ); // Should be no change.
+	}
+
+	/**
+	 * Test the Capability unregister method.
+	 *
+	 * @return void
+	 */
+	public function test_capability_can_be_unregistered() {
+		$capability = new Capability();
+		$capability->register();
+
+		$this->assertFalse( $capability->register() );
+
+		$this->assertRoleHasRedirectsCapability( 'administrator' );
+
+		$capability->unregister();
+
+		$this->assertRoleNotHasRedirectsCapability( 'administrator' );
+
+		$this->assertTrue( $capability->register() );
+	}
+
+	/**
+	 * Check if a specific user has Redirects capability.
+	 *
+	 * @param int|WP_User $user ID of the user, or WP_User object.
+	 * @return bool True if the user has the redirects capability, false otherwise.
+	 */
+	private function assertUserHasRedirectCapability( $user ) {
+
+		if ( is_numeric( $user ) ) {
+			$user = wp_set_current_user( $user );
+		}
+
+		return $this->assertTrue( $user->has_cap( Capability::MANAGE_REDIRECTS_CAPABILITY ) );
+	}
+
+	/**
+	 * Check if a specific user does NOT have Redirects capability.
+	 *
+	 * @param int|WP_User $user ID of the user, or WP_User object.
+	 * @return bool True if the user does not have the redirects capability, false otherwise.
+	 */
+	private function assertUserNotHasRedirectCapability( $user ) {
+
+		if ( is_numeric( $user ) ) {
+			$user = wp_set_current_user( $user );
+		}
+
+		return $this->assertFalse( $user->has_cap( Capability::MANAGE_REDIRECTS_CAPABILITY ) );
+	}
+
+	/**
+	 * Check if a role has Redirects capability.
+	 *
+	 * @param string $role Name of the role to check e.g. administrator.
+	 * @return bool True if the role has the redirects capability, false otherwise.
+	 */
+	private function assertRoleHasRedirectsCapability( $role ) {
+		$user_id = $this->factory->user->create( array( 'role' => $role ) );
+		$user    = wp_set_current_user( $user_id );
+
+		return $this->assertUserHasRedirectCapability( $user );
+	}
+
+	/**
+	 * Check if a role does NOT have Redirects capability.
+	 *
+	 * @param string $role Name of the role to check e.g. administrator.
+	 * @return bool True if the role does not have the redirects capability, false otherwise.
+	 */
+	private function assertRoleNotHasRedirectsCapability( $role ) {
+		$user_id = $this->factory->user->create( array( 'role' => $role ) );
+		$user    = wp_set_current_user( $user_id );
+
+		return $this->assertUserNotHasRedirectCapability( $user );
+	}
+}

--- a/tests/unit/CapabilityTest.php
+++ b/tests/unit/CapabilityTest.php
@@ -1,0 +1,45 @@
+<?php
+namespace Automattic\LegacyRedirector\Tests\Unit;
+
+use Automattic\LegacyRedirector\Capability;
+use Brain\Monkey\Functions;
+use Brain\Monkey;
+use Yoast\WPTestUtils\BrainMonkey\TestCase;
+
+/**
+ * Capability Class Unit Test
+ */
+class CapabilityTest extends TestCase {
+
+	/**
+	 * Test Capability->register method to make sure update_option is only called once and mocking wpcom_vip_add_role_caps function
+	 *
+	 * @return void
+	 */
+	public function test_register() {
+
+		$capability = new Capability();
+
+		Functions\when( 'wpcom_vip_add_role_caps' )
+			->justReturn( true );
+
+		Functions\expect( 'get_option' )
+			->once()
+			->andReturn( 0 );
+
+			Functions\expect( 'update_option' )
+			->once()
+			->andReturn( true );
+
+		$capability->register();
+
+		Functions\expect( 'get_option' )
+			->once()
+			->andReturn( $capability::CAPABILITIES_VER );
+
+			Functions\expect( 'update_option' )
+			->never();
+
+		$capability->register();
+	}
+}


### PR DESCRIPTION
It fixes the issue mentioned in #77  by renaming the activation hook to admin_init and adding a version check to only init the roles once when the version changes as per https://docs.wpvip.com/how-tos/customize-user-roles/ .

PR #93 might need to be merged before this.