### PR TITLE
Insert redirect: allow return of inserted post ID

### DIFF
--- a/includes/class-wpcom-legacy-redirector.php
+++ b/includes/class-wpcom-legacy-redirector.php
@@ -113,9 +113,10 @@ class WPCOM_Legacy_Redirector {
 	 * @param string     $from_url    URL or path that should be redirected; should have leading slash if path.
 	 * @param int|string $redirect_to The post ID or URL to redirect to.
 	 * @param bool       $validate    Validate $from_url and $redirect_to values.
-	 * @return bool|WP_Error True if inserted; false if not permitted; otherwise error upon validation issue.
+	 * @param bool       $return_id   Return the insertd post ID if successful, rather than boolean true.
+	 * @return bool|WP_Error True or post ID if inserted; false if not permitted; otherwise error upon validation issue.
 	 */
-	static function insert_legacy_redirect( $from_url, $redirect_to, $validate = true ) {
+	static function insert_legacy_redirect( $from_url, $redirect_to, $validate = true, $return_id = false ) {
 		if ( ! ( defined( 'WP_CLI' ) && WP_CLI ) && ! is_admin() && ! apply_filters( 'wpcom_legacy_redirector_allow_insert', false ) ) {
 			// Never run on the front end.
 			return false;
@@ -151,9 +152,13 @@ class WPCOM_Legacy_Redirector {
 			return new WP_Error( 'invalid-redirect-url', 'Invalid redirect_to param; should be a post_id or a URL' );
 		}
 
-		wp_insert_post( $args );
+		$inserted_post_id = wp_insert_post( $args );
 
 		wp_cache_delete( $from_url_hash, self::CACHE_GROUP );
+
+		if ( $return_id ) {
+			return $inserted_post_id;
+		}
 
 		return true;
 	}

--- a/tests/Integration/RedirectsTest.php
+++ b/tests/Integration/RedirectsTest.php
@@ -36,14 +36,18 @@ final class RedirectsTest extends TestCase {
 	/**
 	 * @dataProvider get_redirect_data
 	 */
-	function test_redirect( $from, $to ) {
+	public function test_redirect_is_inserted_successfully_and_returns_true( $from, $to ) {
 		$redirect = WPCOM_Legacy_Redirector::insert_legacy_redirect( $from, $to, false );
-		$this->assertTrue( $redirect, 'insert_legacy_redirect failed' );
+		$this->assertTrue( $redirect, 'insert_legacy_redirect() and return true, failed' );
 
 		$redirect = Lookup::get_redirect_uri( $from );
-		$this->assertEquals( $redirect, $to, 'get_redirect_uri failed' );
+		$this->assertEquals( $redirect, $to, 'get_redirect_uri(), failed' );
 	}
 
+	public function test_redirect_is_inserted_successfully_and_returns_post_id() {
+		$redirect = WPCOM_Legacy_Redirector::insert_legacy_redirect( '/simple-redirect', 'http://example.com', false, true );
+		self::assertIsInt( $redirect, 'insert_legacy_redirect() and return post ID, failed' );
+	}
 
 	/**
 	 * Data Provider of Redirect Rules and test urls for Protected Params
@@ -88,7 +92,7 @@ final class RedirectsTest extends TestCase {
 	 *
 	 * @dataProvider get_protected_redirect_data
 	 */
-	function test_protected_query_redirect( $from, $to, $protected_from, $protected_to ) {
+	public function test_protected_query_redirect( $from, $to, $protected_from, $protected_to ) {
 		add_filter(
 			'wpcom_legacy_redirector_preserve_query_params',
 			function( $preserved_params ) {


### PR DESCRIPTION
The `insert_legacy_redirect()` method will return "True if inserted; false if not permitted; otherwise error upon validation issue.".

Rather than just returning boolean `true` when a redirect has been successfully inserted, we can instead return the ID of the entry so that further work may be done with it by other code.

If we updated the `true` return, then this may break existing `===` checks. Instead, we add a new param to the method and which can dictate whether true or the post ID is returned on success.

Fixes #99.