### PR TITLE
Unit Tests: Disable code coverage by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/coverage/
 /vendor/
 /composer.lock
 /.phpcs.xml

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,9 @@
     "test": [
       "@php ./vendor/phpunit/phpunit/phpunit"
     ],
+	"test-coverage": [
+      "@php ./vendor/phpunit/phpunit/phpunit --coverage-text --coverage-html=coverage && echo coverage/index.html"
+    ],
     "integration-test": [
       "@php ./vendor/phpunit/phpunit/phpunit -c phpunit-integration.xml.dist"
     ]

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -32,8 +32,4 @@
 		</whitelist>
 	</filter>
 
-	<logging>
-		<log type="coverage-text" target="php://stdout"/>
-		<!--<log type="coverage-html" target="coverage"/>-->
-	</logging>
 </phpunit>


### PR DESCRIPTION
Including code coverage when running unit tests increases the time from 500ms to around 4.5s, so disable it by default, but add a Composer script to allow it to be easily run locally as needed.

The `echo coverage/index.html` allows a CMD-click in some terminals to immediately open the HTML report.