### PR TITLE
Fix: Allow insert-redirect to work with Post IDs

### DIFF
--- a/includes/class-wpcom-legacy-redirector.php
+++ b/includes/class-wpcom-legacy-redirector.php
@@ -390,7 +390,7 @@ class WPCOM_Legacy_Redirector {
 	 * @return bool|string True on success, false if parent not found, 'private' if not published.
 	 */
 	public static function vip_legacy_redirect_parent_id( $post ) {
-		if ( isset( $_POST['redirect_to'] ) && true !== self::check_if_excerpt_is_home( $post ) ) {
+		if ( true !== self::check_if_excerpt_is_home( $post ) ) {
 			if ( null !== get_post( $post ) && 'publish' === get_post_status( $post ) ) {
 				return true;
 			}


### PR DESCRIPTION
The un-necessary check for a superglobal $_POST was stopping a CLI command like `wp wpcom-legacy-redirector insert-redirect /foo 5` from working correctly.