### PR TITLE
Tests: Add Behat tests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,7 +14,7 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 indent_style = tab
 
-[*.yml]
+[{*.yml,*.feature}]
 indent_style = space
 indent_size = 2
 

--- a/behat.yml
+++ b/behat.yml
@@ -1,0 +1,7 @@
+default:
+  suites:
+    default:
+      contexts:
+        - Automattic\LegacyRedirector\Tests\Behat\FeatureContext
+      paths:
+        - features

--- a/bin/install-package-tests
+++ b/bin/install-package-tests
@@ -1,0 +1,97 @@
+#!/bin/sh
+
+# Database credentials can be provided via environment variables:
+# - WP_CLI_TEST_DBHOST is the host to use and can include a port, i.e "127.0.0.1:33060" (defaults to "localhost")
+# - WP_CLI_TEST_DBROOTUSER is the user that has permission to administer databases and users (defaults to "root").
+# - WP_CLI_TEST_DBROOTPASS is the password to use for the above user (defaults to an empty password).
+# - WP_CLI_TEST_DBNAME is the database that the tests run under (defaults to "wp_cli_test").
+# - WP_CLI_TEST_DBUSER is the user that the tests run under (defaults to "wp_cli_test").
+# - WP_CLI_TEST_DBPASS is the password to use for the above user (defaults to "password1").
+
+HOST=localhost
+PORT=""
+HOST_STRING=''
+if [ -n "${WP_CLI_TEST_DBHOST}" ]; then
+	case ${WP_CLI_TEST_DBHOST##*[]]} in
+		(*:*) HOST=${WP_CLI_TEST_DBHOST%:*} PORT=${WP_CLI_TEST_DBHOST##*:};;
+		(*)   HOST=${WP_CLI_TEST_DBHOST};;
+	esac
+  HOST_STRING="-h${HOST}"
+  if [ -n "${PORT}" ]; then
+  	HOST_STRING="${HOST_STRING} -P${PORT} --protocol=tcp"
+	fi
+fi
+
+USER=root
+if [ -n "${WP_CLI_TEST_DBROOTUSER}" ]; then
+  USER="${WP_CLI_TEST_DBROOTUSER}"
+fi
+
+PASSWORD_STRING=""
+if [ -n "${WP_CLI_TEST_DBROOTPASS}" ]; then
+  PASSWORD_STRING="-p${WP_CLI_TEST_DBROOTPASS}"
+fi
+
+TEST_DB=wp_cli_test
+if [ -n "${WP_CLI_TEST_DBNAME}" ]; then
+  TEST_DB="${WP_CLI_TEST_DBNAME}"
+fi
+
+TEST_USER=wp_cli_test
+if [ -n "${WP_CLI_TEST_DBUSER}" ]; then
+  TEST_USER="${WP_CLI_TEST_DBUSER}"
+fi
+
+TEST_PASSWORD=password1
+if [ -n "${WP_CLI_TEST_DBPASS}" ]; then
+  TEST_PASSWORD="${WP_CLI_TEST_DBPASS}"
+fi
+
+echo 'Checking if MySQL is ready...'
+while ! mysql --user="${USER}" "${PASSWORD_STRING}" --execute="SHOW DATABASES;" | grep 'information_schema' >/dev/null;
+do
+  echo 'Waiting for MySQL...'
+  sleep 5
+  i=$((i+1))
+  if [ $i -gt 36 ]; then
+	echo 'MySQL failed to start. Aborting.'
+	exit 1
+  fi
+done
+
+# Prepare the database for running the tests with a MySQL version 8.0 or higher.
+install_mysql_db_8_0_plus() {
+	set -ex
+	mysql -e "CREATE DATABASE IF NOT EXISTS \`${TEST_DB}\`;" ${HOST_STRING} -u"${USER}" "${PASSWORD_STRING}"
+	mysql -e "CREATE USER IF NOT EXISTS \`${TEST_USER}\`@'%' IDENTIFIED WITH mysql_native_password BY '${TEST_PASSWORD}'" ${HOST_STRING} -u"${USER}" "${PASSWORD_STRING}"
+	mysql -e "GRANT ALL PRIVILEGES ON \`${TEST_DB}\`.* TO '${TEST_USER}'@'%'" ${HOST_STRING} -u"${USER}" "${PASSWORD_STRING}"
+	mysql -e "GRANT ALL PRIVILEGES ON \`${TEST_DB}_scaffold\`.* TO '${TEST_USER}'@'%'" ${HOST_STRING} -u"${USER}" "${PASSWORD_STRING}"
+}
+
+# Prepare the database for running the tests with a MySQL version lower than 8.0.
+install_mysql_db_lower_than_8_0() {
+	set -ex
+	mysql -e "CREATE DATABASE IF NOT EXISTS \`${TEST_DB}\`;" ${HOST_STRING} -u"${USER}" "${PASSWORD_STRING}"
+	mysql -e "GRANT ALL ON \`${TEST_DB}\`.* TO '${TEST_USER}'@'%' IDENTIFIED BY '${TEST_PASSWORD}'" ${HOST_STRING} -u"${USER}" "${PASSWORD_STRING}"
+	mysql -e "GRANT ALL ON \`${TEST_DB}_scaffold\`.* TO '${TEST_USER}'@'%' IDENTIFIED BY '${TEST_PASSWORD}'" ${HOST_STRING} -u"${USER}" "${PASSWORD_STRING}"
+}
+
+VERSION_STRING=$(mysql -e "SELECT VERSION()" --skip-column-names ${HOST_STRING} -u"${USER}" "${PASSWORD_STRING}")
+VERSION=$(echo "${VERSION_STRING}" | grep -o '^[^-]*')
+MAJOR=$(echo "${VERSION}" | cut -d. -f1)
+MINOR=$(echo "${VERSION}" | cut -d. -f2)
+TYPE="MySQL"
+case "${VERSION_STRING}" in
+	*"MariaDB"*)
+		TYPE="MariaDB"
+		;;
+esac
+
+echo "Detected ${TYPE} at version ${MAJOR}.${MINOR}"
+
+
+if [ "${TYPE}" != "MariaDB" ] && [ "${MAJOR}" -ge 8 ]; then
+	install_mysql_db_8_0_plus
+else
+	install_mysql_db_lower_than_8_0
+fi

--- a/bin/rerun-behat-tests
+++ b/bin/rerun-behat-tests
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# To retrieve the WP-CLI tests package root folder, we start with this scripts
+# location.
+SOURCE="${BASH_SOURCE[0]}"
+
+# Resolve $SOURCE until the file is no longer a symlink.
+while [ -h "$SOURCE" ]; do
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  # If $SOURCE was a relative symlink, we need to resolve it relative to the
+  # path where the symlink file was located.
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+
+# Fetch the root folder of the WP-CLI tests package.
+WP_CLI_TESTS_ROOT="$( cd -P "$( dirname "$SOURCE" )/.." && pwd )"
+export WP_CLI_TESTS_ROOT
+
+"$WP_CLI_TESTS_ROOT"/bin/run-behat-tests --rerun "$@"

--- a/bin/run-behat-tests
+++ b/bin/run-behat-tests
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Run the Behat tests only if a Behat config file is found.
+if [ ! -f "behat.yml" ]; then
+	echo 'Did not detect "behat.yml" file, skipping Behat tests.'
+  exit 0;
+fi
+
+if ! command -v jq &> /dev/null
+then
+    echo 'The required "jq" command was not found, please install it to run the Behat tests.'
+    echo "See https://stedolan.github.io/jq/download/ for installation instructions."
+    exit 1;
+fi
+
+if [[ "$@" == *"--help"* ]]; then
+    vendor/bin/behat "$@"
+    ret=$?
+    exit $ret
+fi
+
+# Turn WP_VERSION into an actual number to make sure our tags work correctly.
+if [ "${WP_VERSION-latest}" = "latest" ]; then
+	export WP_VERSION=$(curl -s https://api.wordpress.org/core/version-check/1.7/ | jq -r ".offers[0].current")
+fi
+
+# To retrieve the WP-CLI tests package root folder, we start with this scripts
+# location.
+SOURCE="${BASH_SOURCE[0]}"
+
+# Resolve $SOURCE until the file is no longer a symlink.
+while [ -h "$SOURCE" ]; do
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  # If $SOURCE was a relative symlink, we need to resolve it relative to the
+  # path where the symlink file was located.
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+
+# Fetch the root folder of the WP-CLI tests package.
+WP_CLI_TESTS_ROOT="$( cd -P "$( dirname "$SOURCE" )/.." && pwd )"
+export WP_CLI_TESTS_ROOT
+
+# Generate the tags to apply environment-specific filters.
+BEHAT_TAGS=$(php "$WP_CLI_TESTS_ROOT"/utils/behat-tags.php)
+
+# Run the functional tests.
+vendor/bin/behat --format progress "$BEHAT_TAGS" --strict "$@"

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,9 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^5 | ^6 | ^7 | ^8 | ^9",
-    "polevaultweb/phpunit-wp-cli-runner": "dev-master",
+	"wp-cli/extension-command": "^2.0",
+	"wp-cli/entity-command": "^2.5",
+	"wp-cli/wp-cli-tests": "^3",
     "yoast/wp-test-utils": "^1.1"
   },
   "support": {
@@ -28,6 +30,11 @@
       "includes/"
     ]
   },
+  "autoload-dev": {
+    "psr-4": {
+      "Automattic\\LegacyRedirector\\Tests\\": "tests/"
+	}
+  },
   "scripts": {
     "test": [
       "@php ./vendor/phpunit/phpunit/phpunit --testdox"
@@ -37,11 +44,15 @@
     ],
     "integration-test": [
       "@php ./vendor/phpunit/phpunit/phpunit --testdox -c phpunit-integration.xml.dist"
-    ]
+    ],
+	"behat": "run-behat-tests",
+	"behat-rerun": "rerun-behat-tests",
+	"prepare-tests": "install-package-tests"
   },
   "config": {
     "allow-plugins": {
-      "composer/installers": true
+      "composer/installers": true,
+      "dealerdirect/phpcodesniffer-composer-installer": true
     }
   }
 }

--- a/features/find-domains.feature
+++ b/features/find-domains.feature
@@ -1,0 +1,11 @@
+Feature: Test that the Find Domains subcommand works correctly.
+
+  Background:
+    Given a WP installation with the WPCOM Legacy Redirector plugin
+
+  Scenario: WPCOM Legacy Redirector finds zero domains by default
+    When I run `wp wpcom-legacy-redirector find-domains`
+    Then STDOUT should contain:
+      """
+      Found 0 unique outbound domains
+      """

--- a/features/insert-redirect.feature
+++ b/features/insert-redirect.feature
@@ -1,0 +1,29 @@
+Feature: Test that the Insert Redirect subcommand works correctly.
+
+  Background:
+    Given a WP installation with the WPCOM Legacy Redirector plugin
+
+  Scenario: WPCOM Legacy Redirector nserts a redirect with a path
+    Given I run `wp post create --post_title='Bar' --post_name='bar' --post_status="publish"`
+
+    When I run `wp wpcom-legacy-redirector insert-redirect /foo /bar`
+    Then STDOUT should contain:
+      """
+      Success: Inserted /foo -> /bar
+      """
+
+  @broken
+  Scenario: WP-CLI inserts a redirect with a post ID
+    Given I run `wp post create --post_title='Test post' --post_status="publish" --porcelain`
+    Then save STDOUT as {POST_ID}
+    Given I run `wp post list`
+    Then STDOUT should contain:
+      """
+      Test
+      """
+
+    When I run `wp wpcom-legacy-redirector insert-redirect /foo1 {POST_ID}`
+    Then STDOUT should contain:
+      """
+      Success: Inserted /foo1 -> {POST_ID}
+      """

--- a/features/testing.feature
+++ b/features/testing.feature
@@ -1,0 +1,28 @@
+Feature: Test that WP-CLI and the WPCOM Legacy Redirector command loads.
+
+  Scenario: WP-CLI loads for your tests
+    Given a WP install
+
+    When I run `wp eval 'echo "Hello world.";'`
+    Then STDOUT should contain:
+      """
+      Hello world.
+      """
+
+  Scenario: WP-CLI recognises plugin commands
+    Given a WP install
+
+    When I run `wp plugin --help`
+    Then STDOUT should contain:
+      """
+      Manages plugins, including installs, activations, and updates.
+      """
+
+  Scenario: WP-CLI recognises wpcom-legacy-redirector commands when the plugin is loaded
+    Given a WP installation with the WPCOM Legacy Redirector plugin
+
+    When I run `wp wpcom-legacy-redirector --help`
+    Then STDOUT should contain:
+      """
+      Manage redirects added via the WPCOM Legacy Redirector plugin.
+      """

--- a/tests/Behat/FeatureContext.php
+++ b/tests/Behat/FeatureContext.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Class FeatureContext.
+ *
+ * Feature tests context class with Traduttore-specific steps.
+ */
+
+namespace Automattic\LegacyRedirector\Tests\Behat;
+
+use WP_CLI\Tests\Context\FeatureContext as WP_CLI_FeatureContext;
+
+/**
+ * Feature tests context class with WPCOM Legacy Redirector-specific steps.
+ *
+ * This class extends the one that is provided by the wp-cli/wp-cli-tests package.
+ * To see a list of all recognized step definitions, run `vendor/bin/behat -dl`.
+ */
+final class FeatureContext extends WP_CLI_FeatureContext {
+
+	/**
+	 * @Given a WP install(ation) with the WPCOM legacy Redirector plugin
+	 *
+	 * Adapted from https://github.com/wearerequired/traduttore/blob/master/tests/phpunit/tests/Behat/FeatureContext.php
+	 * with credit and thanks to them.
+	 */
+	public function given_a_wp_installation_with_the_wpcomlr_plugin(): void {
+		$this->install_wp();
+
+		// Symlink the current project folder into the WP folder as a plugin.
+		$project_dir = realpath( self::get_vendor_dir() . '/../' );
+		$plugin_dir  = $this->variables['RUN_DIR'] . '/wp-content/plugins';
+		//$this->ensure_dir_exists( $plugin_dir );
+		$this->proc( "ln -s {$project_dir} {$plugin_dir}/wpcom-legacy-redirector" )->run_check();
+
+		// Activate the plugin.
+		$this->proc( 'wp plugin activate wpcom-legacy-redirector' )->run_check();
+	}
+
+	/**
+	 * Ensure that a requested directory exists and create it recursively as needed.
+	 *
+	 * Copied as is from the Tradutorre repo as well.
+	 *
+	 * @param string $directory Directory to ensure the existence of.
+	 */
+	private function ensure_dir_exists( $directory ): void {
+		$parent = dirname( $directory );
+
+		if ( ! empty( $parent ) && ! is_dir( $parent ) ) {
+			$this->ensure_dir_exists( $parent );
+		}
+
+		if ( ! is_dir( $directory ) && ! mkdir( $directory ) && ! is_dir( $directory ) ) {
+			throw new \RuntimeException( "Could not create directory '{$directory}'." );
+		}
+	}
+}

--- a/tests/Unit/bootstrap.php
+++ b/tests/Unit/bootstrap.php
@@ -1,6 +1,5 @@
 <?php
 
 $vendor_dir = dirname( dirname( __DIR__ ) ) . '/vendor';
-\Polevaultweb\PHPUnit_WP_CLI_Runner\Runner::init( $vendor_dir );
 require_once $vendor_dir . '/yoast/wp-test-utils/src/BrainMonkey/bootstrap.php';
 require_once $vendor_dir . '/autoload.php';


### PR DESCRIPTION
Behat is used for functional tests. Here, it's specifically used for testing the custom WP-CLI commands. Only a few tests are added to begin with, but more can now be added. One test is tagged with `@broken` which means it is skipped for now (the test is good, but #117 needs addressing).

- bin/ scripts are from `wp scaffold package-tests`. The install script only needs to be run once. The other scripts are run via Composer scripts. Thanks @schlessera!
- FeatureContext.php includes code from @swissspidy via the [Traduttore plugin](https://github.com/wearerequired/traduttore/blob/master/tests/phpunit/tests/Behat/FeatureContext.php) - thanks!