### PR TITLE
Composer: Add PHPCS + WPCS

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -1,0 +1,59 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="wpcom-legacy-redirector" xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd">
+	<description>Custom ruleset for wpcom-legacy-redirector plugin.</description>
+
+	<!-- For help in understanding this file: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
+	<!-- For help in using PHPCS: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage -->
+
+	<!-- What to scan -->
+	<file>.</file>
+	<!-- Ignoring Files and Folders:
+		https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-files-and-folders -->
+	<exclude-pattern>/vendor/</exclude-pattern>
+
+	<!-- How to scan -->
+	<!-- Usage instructions: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage -->
+	<!-- Annotated ruleset: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
+	<!-- Show sniff and progress -->
+	<arg value="sp"/>
+	<!-- Strip the file paths down to the relevant bit -->
+	<arg name="basepath" value="./"/>
+	<!-- Show results with colors -->
+	<arg name="colors"/>
+	<!-- Limit to PHP files -->
+	<arg name="extensions" value="php"/>
+	<!-- Enables parallel processing when available for faster results. -->
+	<arg name="parallel" value="8"/>
+
+	<!-- For help in understanding this testVersion:
+		https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions -->
+	<config name="testVersion" value="5.6-"/>
+
+	<!-- Rules: WordPress Coding Standards - see
+		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards -->
+	<!-- WordPress-Extra includes WordPress-Core -->
+	<rule ref="WordPress-Extra"/>
+	<rule ref="WordPress-Docs"/>
+	<!-- For help in understanding these custom sniff properties:
+		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties -->
+	<config name="minimum_supported_wp_version" value="4.5"/>
+
+	<rule ref="WordPress.WP.I18n">
+		<properties>
+			<property name="text_domain" type="array">
+				<element value="wpcom-legacy-redirector"/>
+			</property>
+		</properties>
+	</rule>
+
+	<rule ref="WordPress.WhiteSpace.ControlStructureSpacing">
+		<properties>
+			<property name="blank_line_check" value="true"/>
+		</properties>
+	</rule>
+
+	<rule ref="WordPress.Files.FileName">
+		<exclude-pattern>tests/</exclude-pattern>
+	</rule>
+
+</ruleset>

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
 	"wp-cli/extension-command": "^2.0",
 	"wp-cli/entity-command": "^2.5",
 	"wp-cli/wp-cli-tests": "^3",
+	"wp-coding-standards/wpcs": "^2.3",
     "yoast/wp-test-utils": "^1.1"
   },
   "support": {
@@ -36,6 +37,7 @@
 	}
   },
   "scripts": {
+	"cs": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs",
     "test": [
       "@php ./vendor/phpunit/phpunit/phpunit --testdox"
     ],

--- a/includes/class-capability.php
+++ b/includes/class-capability.php
@@ -1,7 +1,15 @@
 <?php
+/**
+ * Capability class
+ *
+ * @package Automattic\LegacyRedirector
+ */
 
 namespace Automattic\LegacyRedirector;
 
+/**
+ * Capability class.
+ */
 final class Capability {
 	const MANAGE_REDIRECTS_CAPABILITY = 'manage_redirects';
 
@@ -12,7 +20,6 @@ final class Capability {
 	 * Add custom capability onto some existing roles using VIP Helpers with fallbacks.
 	 */
 	public function register() {
-
 		$capabilities_version_key = $this->get_capabilities_version_key();
 
 		// We disable capabilities register unless there is a version increment.
@@ -37,12 +44,9 @@ final class Capability {
 	}
 
 	/**
-	 * Unregister the capabilities
-	 *
-	 * @return void
+	 * Unregister the capabilities.
 	 */
 	public function unregister() {
-
 		$capabilities_version_key = $this->get_capabilities_version_key();
 
 		if ( function_exists( 'wpcom_vip_remove_role_caps' ) ) {

--- a/includes/class-list-redirects.php
+++ b/includes/class-list-redirects.php
@@ -1,9 +1,20 @@
 <?php
+/**
+ * List Redirects class
+ *
+ * @package Automattic\LegacyRedirector
+ */
 
 namespace Automattic\LegacyRedirector;
 
+/**
+ * List redirects class.
+ */
 final class List_Redirects {
-	
+
+	/**
+	 * Initialize integration.
+	 */
 	public function init() {
 		add_filter( 'manage_vip-legacy-redirect_posts_columns', array( $this, 'set_columns' ) );
 		add_action( 'manage_vip-legacy-redirect_posts_custom_column', array( $this, 'posts_custom_column' ), 10, 2 );
@@ -18,9 +29,9 @@ final class List_Redirects {
 	public function set_columns( $columns ) {
 		return array(
 			'cb'   => '<input type="checkbox" />',
-			'from' => __( 'Redirect From' ),
-			'to'   => __( 'Redirect To' ),
-			'date' => __( 'Date' ),
+			'from' => __( 'Redirect From', 'wpcom-legacy-redirector' ),
+			'to'   => __( 'Redirect To', 'wpcom-legacy-redirector' ),
+			'date' => __( 'Date', 'wpcom-legacy-redirector' ),
 		);
 	}
 
@@ -43,7 +54,7 @@ final class List_Redirects {
 
 				// Check if the Post is Published.
 				if ( ! empty( $excerpt ) ) {
-					// Check if it's the Home URL
+					// Check if it's the Home URL.
 					if ( true === \WPCOM_Legacy_Redirector::check_if_excerpt_is_home( $excerpt ) ) {
 						echo esc_html( $excerpt );
 					} elseif ( 0 === strpos( $excerpt, 'http' ) ) {
@@ -74,13 +85,12 @@ final class List_Redirects {
 	/**
 	 * Modify the Row Actions for the vip-legacy-redirect post type.
 	 *
-	 * @param array $actions Default Actions.
-	 * @param object $post the current Post.
+	 * @param array  $actions Default Actions.
+	 * @param object $post    The current Post.
 	 */
 	public function modify_list_row_actions( $actions, $post ) {
 		// Check for your post type.
 		if ( Post_Type::POST_TYPE === $post->post_type ) {
-
 			$url = admin_url( 'post.php?post=vip-legacy-redirect&post=' . $post->ID );
 
 			if ( isset( $_GET['post_status'] ) && 'trash' === $_GET['post_status'] ) {
@@ -90,7 +100,7 @@ final class List_Redirects {
 			$actions = array();
 
 			if ( current_user_can( Capability::MANAGE_REDIRECTS_CAPABILITY ) ) {
-				// Add a nonce to Validate Link
+				// Add a nonce to Validate Link.
 				$validate_link = wp_nonce_url(
 					add_query_arg(
 						array(
@@ -102,7 +112,7 @@ final class List_Redirects {
 					'_validate_redirect'
 				);
 
-				// Add the Validate Link
+				// Add the Validate Link.
 				$actions = array_merge(
 					$actions,
 					array(

--- a/includes/class-lookup.php
+++ b/includes/class-lookup.php
@@ -1,7 +1,15 @@
 <?php
+/**
+ * Lookup class
+ *
+ * @package Automattic\LegacyRedirector
+ */
 
 namespace Automattic\LegacyRedirector;
 
+/**
+ * Lookup class.
+ */
 final class Lookup {
 	const CACHE_GROUP = 'vip-legacy-redirect-2';
 
@@ -11,7 +19,7 @@ final class Lookup {
 	 * @param string $url URL to redirect (source).
 	 * @return string|bool Redirect URL if one was found; otherwise false.
 	 */
-	static function get_redirect_uri( $url ) {
+	public static function get_redirect_uri( $url ) {
 		$url = \WPCOM_Legacy_Redirector::normalise_url( $url );
 		if ( is_wp_error( $url ) ) {
 			return false;
@@ -77,7 +85,7 @@ final class Lookup {
 		 * @param string   $url                    Normalized source URL.
 		 */
 		$preservable_param_keys = apply_filters( 'wpcom_legacy_redirector_preserve_query_params', array(), $url );
-		
+
 		if ( ! is_array( $preservable_param_keys ) ) {
 			throw new \UnexpectedValueException( 'wpcom_legacy_redirector_preserve_query_params must return an array.' );
 		}
@@ -90,7 +98,7 @@ final class Lookup {
 
 		// Parse URL to get querystring parameters.
 		$url_query_params = wp_parse_url( $url, PHP_URL_QUERY );
-		
+
 		// No parameters in URL, so return early.
 		if ( empty( $url_query_params ) ) {
 			return array();
@@ -109,7 +117,7 @@ final class Lookup {
 	 * @param string $url URL to redirect (source).
 	 * @return string|int Redirect post ID (as string) if one was found; otherwise 0.
 	 */
-	static function get_redirect_post_id( $url ) {
+	public static function get_redirect_post_id( $url ) {
 		global $wpdb;
 
 		$url_hash = \WPCOM_Legacy_Redirector::get_url_hash( $url );

--- a/includes/class-post-type.php
+++ b/includes/class-post-type.php
@@ -1,14 +1,32 @@
 <?php
+/**
+ * Post type class
+ *
+ * @package Automattic\LegacyRedirector
+ */
 
 namespace Automattic\LegacyRedirector;
 
+/**
+ * Post type class.
+ */
 final class Post_Type {
 	const POST_TYPE = 'vip-legacy-redirect';
 
+	/**
+	 * Register the post type.
+	 *
+	 * @return void
+	 */
 	public function register() {
 		register_post_type( self::POST_TYPE, $this->get_args() );
 	}
 
+	/**
+	 * Get the post type labels.
+	 *
+	 * @return array
+	 */
 	protected function get_labels() {
 		return array(
 			'name'                  => _x( 'Redirect Manager', 'Post type general name', 'wpcom-legacy-redirector' ),
@@ -28,6 +46,11 @@ final class Post_Type {
 		);
 	}
 
+	/**
+	 * Get the post type arguments.
+	 *
+	 * @return array
+	 */
 	protected function get_args() {
 		return array(
 			'labels'             => $this->get_labels(),

--- a/includes/class-wpcom-legacy-redirector-ui.php
+++ b/includes/class-wpcom-legacy-redirector-ui.php
@@ -1,8 +1,16 @@
 <?php
+/**
+ * WPCOM_Legacy_Redirector_UI class
+ *
+ * @package Automattic\LegacyRedirector
+ */
 
 use \Automattic\LegacyRedirector\Capability;
 use \Automattic\LegacyRedirector\Post_Type;
 
+/**
+ * User interface additions.
+ */
 class WPCOM_Legacy_Redirector_UI {
 	/**
 	 * Constructor Class.
@@ -62,18 +70,21 @@ class WPCOM_Legacy_Redirector_UI {
 
 	/**
 	 * Remove "draft" from the status filters for vip-legacy-redirect post type.
+	 *
+	 * @param array $views Status filters.
+	 * @return array
 	 */
 	public function vip_redirects_custom_post_status_filters( $views ) {
 		unset( $views['draft'] );
 		return $views;
 	}
-	
-	
+
+
 	/**
 	 * Return error data when validate check fails.
 	 *
 	 * @param string $validate String that passes back the validate result in order to output the right notice.
-	 * @param int $post_id The Post ID.
+	 * @param int    $post_id  The Post ID.
 	 */
 	public function vip_legacy_redirect_sendback( $validate, $post_id ) {
 		$sendback = remove_query_arg( array( 'validate', 'ids' ), wp_get_referer() );
@@ -92,7 +103,6 @@ class WPCOM_Legacy_Redirector_UI {
 	 * Validate the Redirect To URL.
 	 */
 	public function validate_vip_legacy_redirect() {
-
 		if ( isset( $_GET['action'] ) && 'validate' === $_GET['action'] ) {
 			$post = get_post( $_GET['post'] );
 			if ( ! isset( $_REQUEST['_validate_redirect'] ) || ! wp_verify_nonce( $_REQUEST['_validate_redirect'], 'validate_vip_legacy_redirect' ) ) {
@@ -177,9 +187,7 @@ class WPCOM_Legacy_Redirector_UI {
 		$errors   = $array[0];
 		$messages = $array[1];
 
-		// phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification -- Not being saved directly, only used to pre-populate field if there was an error on the last submission.
 		$redirect_from_value = isset( $_POST['redirect_from'], $errors[0] ) ? sanitize_text_field( wp_unslash( $_POST['redirect_from'] ) ) : '/';
-		// phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification -- Not being saved directly, only used to pre-populate field if there was an error on the last submission.
 		$redirect_to_value   = isset( $_POST['redirect_to'], $errors[0] ) ? sanitize_text_field( wp_unslash( $_POST['redirect_to'] ) ) : '/';
 		?>
 		<style>

--- a/includes/class-wpcom-legacy-redirector.php
+++ b/includes/class-wpcom-legacy-redirector.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * WPCOM_Legacy_Redirector class
+ *
+ * @package Automattic\LegacyRedirector
+ */
 
 use \Automattic\LegacyRedirector\Capability;
 use \Automattic\LegacyRedirector\List_Redirects;
@@ -16,7 +21,7 @@ class WPCOM_Legacy_Redirector {
 	/**
 	 * Actions and filters.
 	 */
-	static function start() {
+	public static function start() {
 		add_action( 'init', array( __CLASS__, 'init' ) );
 		add_action( 'admin_init', array( __CLASS__, 'admin_init' ) );
 		add_filter( 'template_redirect', array( __CLASS__, 'maybe_do_redirect' ), 0 ); // hook in early, before the canonical redirect.
@@ -28,7 +33,7 @@ class WPCOM_Legacy_Redirector {
 	/**
 	 * Initialize and register other classes during admin_init hook.
 	 */
-	static function admin_init() {
+	public static function admin_init() {
 		$capability = new Capability();
 		$capability->register();
 	}
@@ -36,7 +41,7 @@ class WPCOM_Legacy_Redirector {
 	/**
 	 * Initialize and register other classes.
 	 */
-	static function init() {
+	public static function init() {
 		$post_type = new Post_Type();
 		$post_type->register();
 
@@ -50,7 +55,7 @@ class WPCOM_Legacy_Redirector {
 	 * @param array $actions Current bulk actions available to drop-down.
 	 * @return array Available bulk actions minus edit functionality.
 	 */
-	static function remove_bulk_edit( $actions ) {
+	public static function remove_bulk_edit( $actions ) {
 		unset( $actions['edit'] );
 		return $actions;
 	}
@@ -58,7 +63,7 @@ class WPCOM_Legacy_Redirector {
 	/**
 	 * Performs redirect if current URL is a 404 and redirect rule exists.
 	 */
-	static function maybe_do_redirect() {
+	public static function maybe_do_redirect() {
 		// Avoid the overhead of running this on every single pageload.
 		// We move the overhead to the 404 page but the trade-off for site performance is worth it.
 		if ( ! is_404() ) {
@@ -103,7 +108,7 @@ class WPCOM_Legacy_Redirector {
 			return;
 		}
 
-		wp_enqueue_script( 'wpcom-legacy-redirector', plugins_url( '/../js/admin-add-redirects.js', __FILE__ ), [], WPCOM_LEGACY_REDIRECTOR_VERSION, true );
+		wp_enqueue_script( 'wpcom-legacy-redirector', plugins_url( '/../js/admin-add-redirects.js', __FILE__ ), array(), WPCOM_LEGACY_REDIRECTOR_VERSION, true );
 		wp_localize_script( 'wpcom-legacy-redirector', 'wpcomLegacyRedirector', array( 'siteurl' => get_option( 'siteurl' ) ) );
 	}
 
@@ -116,7 +121,7 @@ class WPCOM_Legacy_Redirector {
 	 * @param bool       $return_id   Return the insertd post ID if successful, rather than boolean true.
 	 * @return bool|WP_Error True or post ID if inserted; false if not permitted; otherwise error upon validation issue.
 	 */
-	static function insert_legacy_redirect( $from_url, $redirect_to, $validate = true, $return_id = false ) {
+	public static function insert_legacy_redirect( $from_url, $redirect_to, $validate = true, $return_id = false ) {
 		if ( ! ( defined( 'WP_CLI' ) && WP_CLI ) && ! is_admin() && ! apply_filters( 'wpcom_legacy_redirector_allow_insert', false ) ) {
 			// Never run on the front end.
 			return false;
@@ -170,7 +175,7 @@ class WPCOM_Legacy_Redirector {
 	 * @param string $redirect_to URL to redirect to (destination).
 	 * @return array|WP_Error Error if invalid redirect URL specified; returns array of params otherwise.
 	 */
-	static function validate_urls( $from_url, $redirect_to ) {
+	public static function validate_urls( $from_url, $redirect_to ) {
 		if ( false !== Lookup::get_redirect_uri( $from_url ) ) {
 			return new WP_Error( 'duplicate-redirect-uri', 'A redirect for this URI already exists' );
 		}
@@ -306,9 +311,9 @@ class WPCOM_Legacy_Redirector {
 			$response = wp_remote_get( $url );
 			// If it was an error, try again with no SSL verification, in case it was a self-signed certificate: https://github.com/Automattic/WPCOM-Legacy-Redirector/issues/64.
 			if ( is_wp_error( $response ) ) {
-				$args     = [
+				$args     = array(
 					'sslverify' => false,
-				];
+				);
 				$response = wp_remote_get( $url, $args );
 			}
 		}
@@ -395,6 +400,9 @@ class WPCOM_Legacy_Redirector {
 				return true;
 			}
 		} else {
+			if ( is_int( $post ) ) {
+				$post = get_post( $post );
+			}
 			$parent = get_post( $post->post_parent );
 			if ( null === get_post( $post->post_parent ) ) {
 				return false;

--- a/tests/Behat/FeatureContext.php
+++ b/tests/Behat/FeatureContext.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Class FeatureContext.
+ * Feature tests context class with WPCOM Legacy Redirector specific steps.
  *
- * Feature tests context class with Traduttore-specific steps.
+ * @package Automattic\LegacyRedirector
  */
 
 namespace Automattic\LegacyRedirector\Tests\Behat;
@@ -18,6 +18,8 @@ use WP_CLI\Tests\Context\FeatureContext as WP_CLI_FeatureContext;
 final class FeatureContext extends WP_CLI_FeatureContext {
 
 	/**
+	 * Set-up the plugin to be active.
+	 *
 	 * @Given a WP install(ation) with the WPCOM legacy Redirector plugin
 	 *
 	 * Adapted from https://github.com/wearerequired/traduttore/blob/master/tests/phpunit/tests/Behat/FeatureContext.php
@@ -29,7 +31,7 @@ final class FeatureContext extends WP_CLI_FeatureContext {
 		// Symlink the current project folder into the WP folder as a plugin.
 		$project_dir = realpath( self::get_vendor_dir() . '/../' );
 		$plugin_dir  = $this->variables['RUN_DIR'] . '/wp-content/plugins';
-		//$this->ensure_dir_exists( $plugin_dir );
+		$this->ensure_dir_exists( $plugin_dir );
 		$this->proc( "ln -s {$project_dir} {$plugin_dir}/wpcom-legacy-redirector" )->run_check();
 
 		// Activate the plugin.
@@ -42,6 +44,7 @@ final class FeatureContext extends WP_CLI_FeatureContext {
 	 * Copied as is from the Tradutorre repo as well.
 	 *
 	 * @param string $directory Directory to ensure the existence of.
+	 * @throws \RuntimeException Directory could not be created.
 	 */
 	private function ensure_dir_exists( $directory ): void {
 		$parent = dirname( $directory );

--- a/tests/Integration/CapabilityTest.php
+++ b/tests/Integration/CapabilityTest.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Capability tests
+ *
+ * @package Automattic\LegacyRedirector
+ */
 
 namespace Automattic\LegacyRedirector\Tests\Integration;
 
@@ -13,13 +18,12 @@ use WP_User;
 final class CapabilityTest extends TestCase {
 
 	/**
-	 * tearDown method to be called after each test.
+	 * Tear down method to be called after each test.
 	 *
 	 * @return void
 	 */
 	public function tear_down() {
-
-		(new Capability())->unregister();
+		( new Capability() )->unregister();
 	}
 
 	/**
@@ -28,7 +32,6 @@ final class CapabilityTest extends TestCase {
 	 * @return void
 	 */
 	public function test_new_admin_capability() {
-
 		$capability = new Capability();
 
 		// We need to force clear capabilities here as the wp_options `roles` option might not get cleared after a failed test.
@@ -81,7 +84,6 @@ final class CapabilityTest extends TestCase {
 	 * @return bool True if the user has the redirects capability, false otherwise.
 	 */
 	private function assertUserHasRedirectCapability( $user ) {
-
 		if ( is_numeric( $user ) ) {
 			$user = wp_set_current_user( $user );
 		}
@@ -96,7 +98,6 @@ final class CapabilityTest extends TestCase {
 	 * @return bool True if the user does not have the redirects capability, false otherwise.
 	 */
 	private function assertUserNotHasRedirectCapability( $user ) {
-
 		if ( is_numeric( $user ) ) {
 			$user = wp_set_current_user( $user );
 		}

--- a/tests/Integration/PostTypeTest.php
+++ b/tests/Integration/PostTypeTest.php
@@ -1,11 +1,21 @@
 <?php
+/**
+ * Post type tests
+ *
+ * @package Automattic\LegacyRedirector
+ */
 
 namespace Automattic\LegacyRedirector\Tests\Integration;
 
 use Automattic\LegacyRedirector\Post_Type;
 
+/**
+ * Post type tests class.
+ */
 final class PostTypeTest extends TestCase {
 	/**
+	 * Test that the post type exists.
+	 *
 	 * @coversNothing
 	 */
 	public function test_post_type_is_registered() {

--- a/tests/Integration/RedirectsTest.php
+++ b/tests/Integration/RedirectsTest.php
@@ -1,12 +1,29 @@
 <?php
+/**
+ * Redirects tests
+ *
+ * @package Automattic\LegacyRedirector
+ */
 
 namespace Automattic\LegacyRedirector\Tests\Integration;
 
 use \Automattic\LegacyRedirector\Lookup;
 use WPCOM_Legacy_Redirector;
 
+/**
+ * Redirects tests class.
+ */
 final class RedirectsTest extends TestCase {
 
+	/**
+	 * Data provider.
+	 *
+	 * Each item in the outermost array should be an array containing:
+	 * - $from path
+	 * - $to destination
+	 *
+	 * @return array<string, array>
+	 */
 	public function get_redirect_data() {
 		return array(
 			'redirect_simple'           => array(
@@ -26,7 +43,7 @@ final class RedirectsTest extends TestCase {
 			),
 
 			'redirect_unicode_in_path'  => array(
-				// https://www.w3.org/International/articles/idn-and-iri/
+				// See https://www.w3.org/International/articles/idn-and-iri/.
 				'/JP納豆',
 				'http://example.com',
 			),
@@ -34,8 +51,12 @@ final class RedirectsTest extends TestCase {
 	}
 
 	/**
+	 * Test redirect is inserted successfully and returns true.
+	 *
 	 * @dataProvider get_redirect_data
-	 * @covers WPCOM_Legacy_Redirector::insert_legacy_redirect
+	 * @covers       WPCOM_Legacy_Redirector::insert_legacy_redirect
+	 * @param string $from From path.
+	 * @param string $to   Destination.
 	 */
 	public function test_redirect_is_inserted_successfully_and_returns_true( $from, $to ) {
 		$redirect = WPCOM_Legacy_Redirector::insert_legacy_redirect( $from, $to, false );
@@ -46,6 +67,8 @@ final class RedirectsTest extends TestCase {
 	}
 
 	/**
+	 * Test redirect is inserted successfully and returns a post ID.
+	 *
 	 * @covers WPCOM_Legacy_Redirector::insert_legacy_redirect
 	 */
 	public function test_redirect_is_inserted_successfully_and_returns_post_id() {
@@ -92,11 +115,15 @@ final class RedirectsTest extends TestCase {
 	}
 
 	/**
-	 * Verify that safelisted parameters are maintained on final redirect urls.
+	 * Verify that safelisted parameters are maintained on final redirect URLs.
 	 *
 	 * @dataProvider get_protected_redirect_data
-	 * @covers WPCOM_Legacy_Redirector::insert_legacy_redirect
-	 * @covers \Automattic\LegacyRedirector\Lookup::get_redirect_uri
+	 * @covers       WPCOM_Legacy_Redirector::insert_legacy_redirect
+	 * @covers       \Automattic\LegacyRedirector\Lookup::get_redirect_uri
+	 * @param string $from           From path.
+	 * @param string $to             Destination.
+	 * @param string $protected_from From path with preserved params.
+	 * @param string $protected_to   Destination. with preserved params.
 	 */
 	public function test_protected_query_redirect( $from, $to, $protected_from, $protected_to ) {
 		add_filter(

--- a/tests/Integration/RedirectsTest.php
+++ b/tests/Integration/RedirectsTest.php
@@ -63,7 +63,7 @@ final class RedirectsTest extends TestCase {
 		$this->assertTrue( $redirect, 'insert_legacy_redirect() and return true, failed' );
 
 		$redirect = Lookup::get_redirect_uri( $from );
-		$this->assertEquals( $redirect, $to, 'get_redirect_uri(), failed' );
+		$this->assertEquals( $redirect, $to, 'get_redirect_uri(), failed - got "' . $redirect . '", expected "' . $to . '"' );
 	}
 
 	/**

--- a/tests/Integration/TestCase.php
+++ b/tests/Integration/TestCase.php
@@ -1,9 +1,17 @@
 <?php
+/**
+ * Integration tests testcase
+ *
+ * @package Automattic\LegacyRedirector
+ */
 
 namespace Automattic\LegacyRedirector\Tests\Integration;
 
 use Yoast\WPTestUtils\WPIntegration\TestCase as WPTestUtilsTestCase;
 
+/**
+ * Integrations test testcase class
+ */
 abstract class TestCase extends WPTestUtilsTestCase {
 
 	/**

--- a/tests/Unit/CapabilityTest.php
+++ b/tests/Unit/CapabilityTest.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Capability tests
+ *
+ * @package Automattic\LegacyRedirector
+ */
+
 namespace Automattic\LegacyRedirector\Tests\Unit;
 
 use Automattic\LegacyRedirector\Capability;
@@ -12,12 +18,12 @@ final class CapabilityTest extends TestCase {
 
 	/**
 	 * Test Capability->register method to make sure update_option is only called once and mocking wpcom_vip_add_role_caps function
+	 *
 	 * @covers \Automattic\LegacyRedirector\Capability::register
 	 * @uses \Automattic\LegacyRedirector\Capability::get_capabilities_version_key
 	 * @return void
 	 */
 	public function test_register_method_is_only_called_once() {
-
 		$capability = new Capability();
 
 		Functions\when( 'wpcom_vip_add_role_caps' )

--- a/tests/Unit/CliTest.php
+++ b/tests/Unit/CliTest.php
@@ -1,15 +1,25 @@
 <?php
+/**
+ * CLI tests
+ *
+ * @package Automattic\LegacyRedirector
+ */
 
 namespace Automattic\LegacyRedirector\Tests\Unit;
 
 use WPCOM_Legacy_Redirector_CLI;
 use Yoast\WPTestUtils\BrainMonkey\TestCase;
 
+/**
+ * CLI tests class
+ */
 final class CliTest extends TestCase {
 
 	/**
-	* @covers WPCOM_Legacy_Redirector_CLI::__construct
-	*/
+	 * Test that the CLI class is instantiable.
+	 *
+	 * @covers WPCOM_Legacy_Redirector_CLI::__construct
+	 */
 	public function test_cli_class_is_instantiable() {
 		$cli = new WPCOM_Legacy_Redirector_CLI();
 

--- a/tests/Unit/PreservableParamsTest.php
+++ b/tests/Unit/PreservableParamsTest.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Preservable querystring parameters tests
+ *
+ * @package Automattic\LegacyRedirector
+ */
 
 namespace Automattic\LegacyRedirector\Tests\Unit;
 
@@ -7,11 +12,22 @@ use Brain\Monkey;
 use UnexpectedValueException;
 use Yoast\WPTestUtils\BrainMonkey\TestCase;
 
+/**
+ * Preservable querystring parameters tests.
+ */
 final class PreservableParamsTest extends TestCase {
-
+	/**
+	 * Data provider.
+	 *
+	 * Each item in the outermost array should be an array containing:
+	 *  - $url
+	 *  - $preservable_param_keys
+	 *  - $expected
+	 *
+	 * @return array<string, array>
+	 */
 	public function data_get_preservable_querystring_params_from_url() {
 		return array(
-			// $url, $preservable_param_keys, $expected array.
 			'No querystring'                         => array(
 				'https://example.com',
 				array( 'foo', 'bar', 'baz' ),
@@ -77,26 +93,33 @@ final class PreservableParamsTest extends TestCase {
 			),
 			'Associative array returned from filter' => array(
 				'https://example.com?foo=123&bar=456',
-				array( 'foo' => 0, 'baz' => 1 ),
+				array(
+					'foo' => 0,
+					'baz' => 1,
+				),
 				new UnexpectedValueException(),
 			),
 		);
 	}
 
 	/**
-	* @covers \Automattic\LegacyRedirector\Lookup::get_preservable_querystring_params_from_url
-	* @dataProvider data_get_preservable_querystring_params_from_url
-	*/
+	 * Test that preservable parameters from the querystring are preserved.
+	 *
+	 * @covers       \Automattic\LegacyRedirector\Lookup::get_preservable_querystring_params_from_url
+	 * @dataProvider data_get_preservable_querystring_params_from_url
+	 * @param string $url                    The URL to parse.
+	 * @param array  $preservable_param_keys The keys that should be preserved.
+	 * @param array  $expected               The expected outcome.
+	 */
 	public function test_get_preservable_querystring_params_from_url( $url, $preservable_param_keys, $expected ) {
-
 		Monkey\Filters\expectApplied( 'wpcom_legacy_redirector_preserve_query_params' )
 			->once()
 			->andReturn( $preservable_param_keys );
 
-
 		Monkey\Functions\stubs(
 			array(
 				'wp_parse_url' => static function ( $url, $component ) {
+					// phpcs:ignore WordPress.WP.AlternativeFunctions.parse_url_parse_url
 					return parse_url( $url, $component );
 				},
 			)

--- a/tests/Unit/bootstrap.php
+++ b/tests/Unit/bootstrap.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Unit tests bootstrap
+ *
+ * @package Automattic\LegacyRedirector
+ */
 
 $vendor_dir = dirname( dirname( __DIR__ ) ) . '/vendor';
 require_once $vendor_dir . '/yoast/wp-test-utils/src/BrainMonkey/bootstrap.php';

--- a/wpcom-helper.php
+++ b/wpcom-helper.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Amendments for when this plugin runs on WordPress.com.
+ *
+ * @package Automattic\LegacyRedirector
+ */
 
-// Do not allow inserts to be enabled on the frontend on wpcom
+// Do not allow inserts to be enabled on the front end on WordPress.com.
 add_filter( 'wpcom_legacy_redirector_allow_insert', '__return_false', 9999 );

--- a/wpcom-legacy-redirector.php
+++ b/wpcom-legacy-redirector.php
@@ -1,12 +1,12 @@
 <?php
 /**
  * Plugin Name: WPCOM Legacy Redirector
- * Plugin URI: https://vip.wordpress.com/plugins/wpcom-legacy-redirector/
+ * Plugin URI: https://github.com/Automattic/WPCOM-Legacy-Redirector
  * Description: Simple plugin for handling legacy redirects in a scalable manner.
  * Version: 1.4.0-alpha
  * Requires PHP: 5.6
- * Author: Automattic / WordPress.com VIP
- * Author URI: https://vip.wordpress.com
+ * Author: Automattic / WordPress VIP
+ * Author URI: https://wpvip.com
  *
  * Redirects are stored as a custom post type and use the following fields:
  *
@@ -18,7 +18,7 @@
  *  - post_parent if we're redirect to a post; or
  *  - post_excerpt if we're redirecting to an alternate URL.
  *
- * Please contact us before using this plugin.
+ * @package Automattic\LegacyRedirector
  */
 
 define( 'WPCOM_LEGACY_REDIRECTOR_VERSION', '1.4.0-alpha' );


### PR DESCRIPTION
Adds PHP_CodeSniffer and WordPress Coding Standards. Addresses many, but not all items. The remaining items need more attention.

Includes filling in gaps for the WP-CLI command documentation as well.

See #106 which also covers some of this.