### PR TITLE
Tests: Add more find-domains functional tests

### DIFF
--- a/features/find-domains.feature
+++ b/features/find-domains.feature
@@ -24,7 +24,7 @@ Feature: Test that the Find Domains subcommand works correctly.
     And I run `wp wpcom-legacy-redirector find-domains`
     Then STDOUT should contain:
       """
-      Found 1 unique outbound domains.
+      Found 1 unique outbound domain.
       google.com
       """
 
@@ -37,7 +37,7 @@ Feature: Test that the Find Domains subcommand works correctly.
     When I run `wp wpcom-legacy-redirector find-domains`
     Then STDOUT should contain:
       """
-      Found 1 unique outbound domains.
+      Found 1 unique outbound domain.
       google.com
       """
 

--- a/features/find-domains.feature
+++ b/features/find-domains.feature
@@ -7,5 +7,51 @@ Feature: Test that the Find Domains subcommand works correctly.
     When I run `wp wpcom-legacy-redirector find-domains`
     Then STDOUT should contain:
       """
-      Found 0 unique outbound domains
+      Found 0 unique outbound domains.
+      """
+
+  Scenario: WPCOM Legacy Redirector does not allow redirect to disallowed host.
+    When I try `wp wpcom-legacy-redirector insert-redirect /foo https://google.com`
+    Then STDERR should contain:
+      """
+      Error: Couldn't insert /foo -> https://google.com (If you are doing an external redirect, make sure you safelist the domain using the "allowed_redirect_hosts" filter.)
+      """
+
+  Scenario: WPCOM Legacy Redirector finds one domain from one redirect
+    Given I add google.com to allowed_redirect_hosts
+
+    When I run `wp wpcom-legacy-redirector insert-redirect /foo https://google.com`
+    And I run `wp wpcom-legacy-redirector find-domains`
+    Then STDOUT should contain:
+      """
+      Found 1 unique outbound domains.
+      google.com
+      """
+
+  Scenario: WPCOM Legacy Redirector finds one domain from multiple redirects
+    Given I add google.com to allowed_redirect_hosts
+
+    When I run `wp wpcom-legacy-redirector insert-redirect /foo https://google.com`
+    And I run `wp wpcom-legacy-redirector insert-redirect /foo1 https://google.com/1`
+
+    When I run `wp wpcom-legacy-redirector find-domains`
+    Then STDOUT should contain:
+      """
+      Found 1 unique outbound domains.
+      google.com
+      """
+
+  Scenario: WPCOM Legacy Redirector finds multiple domain from multiple redirects
+    Given I add google.com to allowed_redirect_hosts
+    And I add google.co.uk to allowed_redirect_hosts
+
+    When I run `wp wpcom-legacy-redirector insert-redirect /foo https://google.com`
+    And I run `wp wpcom-legacy-redirector insert-redirect /foo1 https://google.co.uk`
+
+    When I run `wp wpcom-legacy-redirector find-domains`
+    Then STDOUT should contain:
+      """
+      Found 2 unique outbound domains.
+      google.com
+      google.co.uk
       """

--- a/includes/class-wpcom-legacy-redirector-cli.php
+++ b/includes/class-wpcom-legacy-redirector-cli.php
@@ -73,9 +73,13 @@ class WPCOM_Legacy_Redirector_CLI extends WP_CLI_Command {
 
 		$progress->finish();
 
-		$domains = array_unique( $domains );
+		$domains       = array_unique( $domains );
+		$domains_count = count( $domains );
 
-		WP_CLI::line( sprintf( 'Found %s unique outbound domains.', number_format( count( $domains ) ) ) );
+		/* translators: %s = count of the domains */
+		$translatable_text = _n( 'Found %s unique outbound domain.', 'Found %s unique outbound domains.', $domains_count );
+
+		WP_CLI::line( sprintf( $translatable_text, number_format( $domains_count ) ) );
 
 		foreach ( $domains as $domain ) {
 			WP_CLI::line( $domain );

--- a/tests/Behat/FeatureContext.php
+++ b/tests/Behat/FeatureContext.php
@@ -57,4 +57,22 @@ final class FeatureContext extends WP_CLI_FeatureContext {
 			throw new \RuntimeException( "Could not create directory '{$directory}'." );
 		}
 	}
+
+	/**
+	 * Add host to allowed_redirect_hosts.
+	 *
+	 * @Given I add :host to allowed_redirect_hosts
+	 *
+	 * @param string $host Host name to add.
+	 */
+	public function i_add_host_to_allowed_redirect_hosts( $host ) {
+		$filter_allowed_redirect_hosts = <<<PHPCODE
+<?php \add_filter( 'allowed_redirect_hosts', fn( \$hosts ) => array_merge( \$hosts, array( '$host' ) ) );
+PHPCODE;
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_file_put_contents
+		file_put_contents(
+			$this->variables['RUN_DIR'] . "/wp-content/mu-plugins/allowed_redirect_hosts-{$host}.php",
+			$filter_allowed_redirect_hosts
+		);
+	}
 }


### PR DESCRIPTION
The FeatureContext Given step adds some PHP code to a file and saves this as an mu-plugin (one per host) to allow the host to be in the allowed_redirect_hosts WordPress filter, which allows the redirect to be validated. Props to @swissspidy for the idea.

It also improves the plurals grammar around finding a singular outbound domain.