### PR TITLE
Increase minimum PHP, WordPress, and bump dev-dependencies

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -36,7 +36,7 @@
 	<rule ref="WordPress-Docs"/>
 	<!-- For help in understanding these custom sniff properties:
 		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties -->
-	<config name="minimum_supported_wp_version" value="4.5"/>
+	<config name="minimum_supported_wp_version" value="5.9"/>
 
 	<rule ref="WordPress.WP.I18n">
 		<properties>

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -27,7 +27,7 @@
 
 	<!-- For help in understanding this testVersion:
 		https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions -->
-	<config name="testVersion" value="5.6-"/>
+	<config name="testVersion" value="7.4-"/>
 
 	<!-- Rules: WordPress Coding Standards - see
 		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-Requires PHP 5.6.
+Requires PHP 7.4.
 
 ### Added
 - Admin pages to view, add, delete, and validate redirects. Uses new `manage_redirects` capability. 
@@ -19,7 +19,7 @@ Requires PHP 5.6.
 
 ## Changed
 - Improved adherence to WPCS and VIPCS coding standards.
-- Drop PHP 5.3 support.
+- Drop PHP 5.3-7.3 support.
 - Use WP_CLI:error to halt operation on failed insert using `insert-redirect`.
 - Return an error if no redirects were found for a meta key.
 - Added performance improvement for `import-from-meta` command.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 Requires PHP 7.4.
+Requires WordPress 5.9.
 
 ### Added
 - Admin pages to view, add, delete, and validate redirects. Uses new `manage_redirects` capability. 
@@ -29,7 +30,6 @@ Requires PHP 7.4.
 ## Fixed
 - Trim whitespace around CSV file path, to support dragging a file into the terminal window to add the path.
 - Ensure `POST` var is set during CLI command.
-
 
 ## [1.3.0] - 2016-03-29
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Please see our [wiki](https://github.com/Automattic/WPCOM-Legacy-Redirector/wiki
 ## Requirements
 
 - PHP 7.4+
-- WordPress 4.5+
+- WordPress 5.9+
 
 ## Change Log
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Please see our [wiki](https://github.com/Automattic/WPCOM-Legacy-Redirector/wiki
 
 ## Requirements
 
-- PHP 5.6+
+- PHP 7.4+
 - WordPress 4.5+
 
 ## Change Log

--- a/composer.json
+++ b/composer.json
@@ -1,30 +1,30 @@
 {
   "name": "automattic/wpcom-legacy-redirector",
-  "type": "wordpress-plugin",
   "description": "WordPress plugin for handling large volumes of legacy redirects in a scalable manner.",
-  "homepage": "https://github.com/Automattic/WPCOM-Legacy-Redirector",
   "license": "GPL-2.0-or-later",
+  "type": "wordpress-plugin",
   "authors": [
     {
       "name": "Automattic",
       "homepage": "http://automattic.com/"
     }
   ],
-  "require": {
-    "php" : ">=5.6",
-    "composer/installers": "^1"
-  },
-  "require-dev": {
-    "phpunit/phpunit": "^5 | ^6 | ^7 | ^8 | ^9",
-	"wp-cli/extension-command": "^2.0",
-	"wp-cli/entity-command": "^2.5",
-	"wp-cli/wp-cli-tests": "^3",
-	"wp-coding-standards/wpcs": "^2.3",
-    "yoast/wp-test-utils": "^1.1"
-  },
+  "homepage": "https://github.com/Automattic/WPCOM-Legacy-Redirector",
   "support": {
     "issues": "https://github.com/Automattic/WPCOM-Legacy-Redirector/issues",
     "source": "https://github.com/Automattic/WPCOM-Legacy-Redirector"
+  },
+  "require": {
+    "php": ">=5.6",
+    "composer/installers": "^1"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^5 || ^6 || ^7 || ^8 || ^9",
+    "wp-cli/entity-command": "^2.5",
+    "wp-cli/extension-command": "^2.0",
+    "wp-cli/wp-cli-tests": "^3",
+    "wp-coding-standards/wpcs": "^2.3",
+    "yoast/wp-test-utils": "^1.1"
   },
   "autoload": {
     "classmap": [
@@ -34,27 +34,27 @@
   "autoload-dev": {
     "psr-4": {
       "Automattic\\LegacyRedirector\\Tests\\": "tests/"
-	}
-  },
-  "scripts": {
-	"cs": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs",
-    "test": [
-      "@php ./vendor/phpunit/phpunit/phpunit --testdox"
-    ],
-	"test-coverage": [
-      "@php ./vendor/phpunit/phpunit/phpunit --coverage-text --coverage-html=coverage && echo coverage/index.html"
-    ],
-    "integration-test": [
-      "@php ./vendor/phpunit/phpunit/phpunit --testdox -c phpunit-integration.xml.dist"
-    ],
-	"behat": "run-behat-tests",
-	"behat-rerun": "rerun-behat-tests",
-	"prepare-behat-tests": "install-package-tests"
+    }
   },
   "config": {
     "allow-plugins": {
       "composer/installers": true,
       "dealerdirect/phpcodesniffer-composer-installer": true
     }
+  },
+  "scripts": {
+    "behat": "run-behat-tests",
+    "behat-rerun": "rerun-behat-tests",
+    "cs": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs",
+    "integration-test": [
+      "@php ./vendor/phpunit/phpunit/phpunit --testdox -c phpunit-integration.xml.dist"
+    ],
+    "prepare-behat-tests": "install-package-tests",
+    "test": [
+      "@php ./vendor/phpunit/phpunit/phpunit --testdox"
+    ],
+    "test-coverage": [
+      "@php ./vendor/phpunit/phpunit/phpunit --coverage-text --coverage-html=coverage && echo coverage/index.html"
+    ]
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -44,12 +44,16 @@
   "scripts": {
     "behat": "run-behat-tests",
     "behat-rerun": "rerun-behat-tests",
-    "cs": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs",
-    "integration-test": [
+    "cs": "@php ./vendor/bin/phpcs",
+    "prepare-behat-tests": "install-package-tests",
+	"test": [
+      "@php composer test-unit",
+      "@php composer test-integration"
+    ],
+    "test-integration": [
       "@php ./vendor/phpunit/phpunit/phpunit --testdox -c phpunit-integration.xml.dist"
     ],
-    "prepare-behat-tests": "install-package-tests",
-    "test": [
+    "test-unit": [
       "@php ./vendor/phpunit/phpunit/phpunit --testdox"
     ],
     "test-coverage": [

--- a/composer.json
+++ b/composer.json
@@ -16,13 +16,13 @@
   },
   "require": {
     "php": ">=7.4",
-    "composer/installers": "^1"
+    "composer/installers": "^1 || ^2"
   },
   "require-dev": {
-    "wp-cli/entity-command": "^2.5",
-    "wp-cli/extension-command": "^2.0",
-    "wp-cli/wp-cli-tests": "^3",
-    "wp-coding-standards/wpcs": "^2.3",
+    "wp-cli/entity-command": "^2",
+    "wp-cli/extension-command": "^2",
+    "wp-cli/wp-cli-tests": "^4",
+    "wp-coding-standards/wpcs": "^3",
     "yoast/wp-test-utils": "^1.2"
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -19,12 +19,11 @@
     "composer/installers": "^1"
   },
   "require-dev": {
-    "phpunit/phpunit": "^5 || ^6 || ^7 || ^8 || ^9",
     "wp-cli/entity-command": "^2.5",
     "wp-cli/extension-command": "^2.0",
     "wp-cli/wp-cli-tests": "^3",
     "wp-coding-standards/wpcs": "^2.3",
-    "yoast/wp-test-utils": "^1.1"
+    "yoast/wp-test-utils": "^1.2"
   },
   "autoload": {
     "classmap": [

--- a/composer.json
+++ b/composer.json
@@ -1,63 +1,63 @@
 {
-  "name": "automattic/wpcom-legacy-redirector",
-  "description": "WordPress plugin for handling large volumes of legacy redirects in a scalable manner.",
-  "license": "GPL-2.0-or-later",
-  "type": "wordpress-plugin",
-  "authors": [
-    {
-      "name": "Automattic",
-      "homepage": "http://automattic.com/"
-    }
-  ],
-  "homepage": "https://github.com/Automattic/WPCOM-Legacy-Redirector",
-  "support": {
-    "issues": "https://github.com/Automattic/WPCOM-Legacy-Redirector/issues",
-    "source": "https://github.com/Automattic/WPCOM-Legacy-Redirector"
-  },
-  "require": {
-    "php": ">=7.4",
-    "composer/installers": "^1 || ^2"
-  },
-  "require-dev": {
-    "wp-cli/entity-command": "^2",
-    "wp-cli/extension-command": "^2",
-    "wp-cli/wp-cli-tests": "^4",
-    "wp-coding-standards/wpcs": "^3",
-    "yoast/wp-test-utils": "^1.2"
-  },
-  "autoload": {
-    "classmap": [
-      "includes/"
-    ]
-  },
-  "autoload-dev": {
-    "psr-4": {
-      "Automattic\\LegacyRedirector\\Tests\\": "tests/"
-    }
-  },
-  "config": {
-    "allow-plugins": {
-      "composer/installers": true,
-      "dealerdirect/phpcodesniffer-composer-installer": true
-    }
-  },
-  "scripts": {
-    "behat": "run-behat-tests",
-    "behat-rerun": "rerun-behat-tests",
-    "cs": "@php ./vendor/bin/phpcs",
-    "prepare-behat-tests": "install-package-tests",
-	"test": [
-      "@php composer test-unit",
-      "@php composer test-integration"
-    ],
-    "test-integration": [
-      "@php ./vendor/phpunit/phpunit/phpunit --testdox -c phpunit-integration.xml.dist"
-    ],
-    "test-unit": [
-      "@php ./vendor/phpunit/phpunit/phpunit --testdox"
-    ],
-    "test-coverage": [
-      "@php ./vendor/phpunit/phpunit/phpunit --coverage-text --coverage-html=coverage && echo coverage/index.html"
-    ]
-  }
+	"name": "automattic/wpcom-legacy-redirector",
+	"description": "WordPress plugin for handling large volumes of legacy redirects in a scalable manner.",
+	"license": "GPL-2.0-or-later",
+	"type": "wordpress-plugin",
+	"authors": [
+		{
+			"name": "Automattic",
+			"homepage": "http://automattic.com/"
+		}
+	],
+	"homepage": "https://github.com/Automattic/WPCOM-Legacy-Redirector",
+	"support": {
+		"issues": "https://github.com/Automattic/WPCOM-Legacy-Redirector/issues",
+		"source": "https://github.com/Automattic/WPCOM-Legacy-Redirector"
+	},
+	"require": {
+		"php": ">=7.4",
+		"composer/installers": "^1 || ^2"
+	},
+	"require-dev": {
+		"wp-cli/entity-command": "^2",
+		"wp-cli/extension-command": "^2",
+		"wp-cli/wp-cli-tests": "^4",
+		"wp-coding-standards/wpcs": "^3",
+		"yoast/wp-test-utils": "^1.2"
+	},
+	"autoload": {
+		"classmap": [
+			"includes/"
+		]
+	},
+	"autoload-dev": {
+		"psr-4": {
+			"Automattic\\LegacyRedirector\\Tests\\": "tests/"
+		}
+	},
+	"config": {
+		"allow-plugins": {
+			"composer/installers": true,
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		}
+	},
+	"scripts": {
+		"behat": "run-behat-tests",
+		"behat-rerun": "rerun-behat-tests",
+		"cs": "@php ./vendor/bin/phpcs",
+		"prepare-behat-tests": "install-package-tests",
+		"test": [
+			"@php composer test-unit",
+			"@php composer test-integration"
+		],
+		"test-integration": [
+			"@php ./vendor/phpunit/phpunit/phpunit --testdox -c phpunit-integration.xml.dist"
+		],
+		"test-unit": [
+			"@php ./vendor/phpunit/phpunit/phpunit --testdox"
+		],
+		"test-coverage": [
+			"@php ./vendor/phpunit/phpunit/phpunit --coverage-text --coverage-html=coverage && echo coverage/index.html"
+		]
+	}
 }

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "source": "https://github.com/Automattic/WPCOM-Legacy-Redirector"
   },
   "require": {
-    "php": ">=5.6",
+    "php": ">=7.4",
     "composer/installers": "^1"
   },
   "require-dev": {

--- a/wpcom-legacy-redirector.php
+++ b/wpcom-legacy-redirector.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://github.com/Automattic/WPCOM-Legacy-Redirector
  * Description: Simple plugin for handling legacy redirects in a scalable manner.
  * Version: 1.4.0-alpha
- * Requires PHP: 5.6
+ * Requires PHP: 7.4
  * Author: Automattic / WordPress VIP
  * Author URI: https://wpvip.com
  *


### PR DESCRIPTION
Requires PHP 7.4.
Requires WP 5.9.