### PR TITLE
PHPUnit: Refresh config files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,10 +51,10 @@
 			"@php composer test-integration"
 		],
 		"test-integration": [
-			"@php ./vendor/phpunit/phpunit/phpunit --testdox -c phpunit-integration.xml.dist"
+			"@php ./vendor/phpunit/phpunit/phpunit --testdox -c phpunit-integration.xml.dist --no-coverage"
 		],
 		"test-unit": [
-			"@php ./vendor/phpunit/phpunit/phpunit --testdox"
+			"@php ./vendor/phpunit/phpunit/phpunit --testdox --no-coverage"
 		],
 		"test-coverage": [
 			"@php ./vendor/phpunit/phpunit/phpunit --coverage-text --coverage-html=coverage && echo coverage/index.html"

--- a/phpunit-integration.xml.dist
+++ b/phpunit-integration.xml.dist
@@ -1,25 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.5/phpunit.xsd"
-		backupGlobals="false"
-		backupStaticAttributes="false"
-		bootstrap="tests/Integration/bootstrap.php"
-		colors="true"
-		convertErrorsToExceptions="true"
-		convertNoticesToExceptions="true"
-		convertWarningsToExceptions="true"
-		forceCoversAnnotation="true"
-		processIsolation="false"
-		stopOnError="false"
-		stopOnFailure="false"
-		stopOnIncomplete="false"
-		stopOnSkipped="false"
-		verbose="true"
-	>
+	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
+	beStrictAboutChangesToGlobalState="true"
+	beStrictAboutCoversAnnotation="true"
+	beStrictAboutOutputDuringTests="true"
+	bootstrap="tests/Integration/bootstrap.php"
+	colors="true"
+	forceCoversAnnotation="true"
+	verbose="true"
+>
+	<coverage processUncoveredFiles="true">
+		<include>
+			<directory suffix=".php">./includes</directory>
+		</include>
+	</coverage>
 	<testsuites>
 		<testsuite name="integration">
-			<directory suffix="Test.php">./tests/Integration/</directory>
+			<directory>./tests/Integration/</directory>
 		</testsuite>
 	</testsuites>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,34 +2,22 @@
 <phpunit
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
-		backupGlobals="false"
-		backupStaticAttributes="false"
-		beStrictAboutChangesToGlobalState="true"
-		beStrictAboutCoversAnnotation="true"
-		beStrictAboutOutputDuringTests="true"
-		bootstrap="tests/Unit/bootstrap.php"
-		colors="true"
-		convertErrorsToExceptions="true"
-		convertNoticesToExceptions="true"
-		convertWarningsToExceptions="true"
-		forceCoversAnnotation="true"
-		processIsolation="false"
-		stopOnError="false"
-		stopOnFailure="false"
-		stopOnIncomplete="false"
-		stopOnSkipped="false"
-		verbose="true"
-	>
+	beStrictAboutChangesToGlobalState="true"
+	beStrictAboutCoversAnnotation="true"
+	beStrictAboutOutputDuringTests="true"
+	bootstrap="tests/Unit/bootstrap.php"
+	colors="true"
+	forceCoversAnnotation="true"
+	verbose="true"
+>
+	<coverage processUncoveredFiles="true">
+		<include>
+			<directory suffix=".php">./includes</directory>
+		</include>
+	</coverage>
 	<testsuites>
 		<testsuite name="unit">
-			<directory suffix="Test.php">./tests/Unit/</directory>
+			<directory>./tests/Unit/</directory>
 		</testsuite>
 	</testsuites>
-
-	<filter>
-		<whitelist processUncoveredFilesFromWhitelist="true">
-			<directory suffix=".php">./includes</directory>
-		</whitelist>
-	</filter>
-
 </phpunit>


### PR DESCRIPTION
- Use newer schema.
- Remove attributes with default values.
- Use coverage element instead of filter.
- Reformat files.