### PR TITLE
Remove wpcom_vip_get_page_by_path

### DIFF
--- a/includes/class-wpcom-legacy-redirector.php
+++ b/includes/class-wpcom-legacy-redirector.php
@@ -360,12 +360,8 @@ class WPCOM_Legacy_Redirector {
 	 */
 	public static function vip_legacy_redirect_check_if_public( $excerpt ) {
 		$post_types = get_post_types();
+		$post_obj   = get_page_by_path( $excerpt, OBJECT, $post_types );
 
-		if ( function_exists( 'wpcom_vip_get_page_by_path' ) ) {
-			$post_obj = wpcom_vip_get_page_by_path( $excerpt, OBJECT, $post_types );
-		} else {
-			$post_obj = get_page_by_path( $excerpt, OBJECT, $post_types );
-		}
 		if ( ! is_null( $post_obj ) ) {
 			if ( 'publish' !== get_post_status( $post_obj->ID ) ) {
 				return 'private';

--- a/wpcom-legacy-redirector.php
+++ b/wpcom-legacy-redirector.php
@@ -5,7 +5,6 @@
  * Description: Simple plugin for handling legacy redirects in a scalable manner.
  * Version: 1.4.0-alpha
  * Requires PHP: 7.4
- * Requires at least: 6.1
  * Author: Automattic / WordPress VIP
  * Author URI: https://wpvip.com
  *

--- a/wpcom-legacy-redirector.php
+++ b/wpcom-legacy-redirector.php
@@ -5,6 +5,7 @@
  * Description: Simple plugin for handling legacy redirects in a scalable manner.
  * Version: 1.4.0-alpha
  * Requires PHP: 7.4
+ * Requires at least: 6.1
  * Author: Automattic / WordPress VIP
  * Author URI: https://wpvip.com
  *


### PR DESCRIPTION
Removes the now deprecated `wpcom_vip_get_page_by_path` function ~and bumps the minimum WordPress version to 6.1~. 

~The alternative to a version bump would be to leave the function and wrap it in a `version_compare` statement. However, as 6.1 is nearly 2 years old, and 5 major versions ago a version bump seems logical.~ 

~Happy to revisit this PR though if we decide we don't want a WordPress version bump.~

Fixes #134