### PR TITLE
fix: PHP warning when in Utils::mb_parse_url() 

### DIFF
--- a/includes/class-utils.php
+++ b/includes/class-utils.php
@@ -37,6 +37,10 @@ final class Utils {
 
 		$parts = wp_parse_url( $encoded_url, $component );
 
+		if ( null === $parts ) {
+			return null;
+		}
+
 		if ( false === $parts ) {
 			throw new \InvalidArgumentException( 'Malformed URL: ' . $url );
 		}


### PR DESCRIPTION
This pull request includes a minor change to the `includes/class-utils.php` file to handle potential null values when parsing URLs.

* [`includes/class-utils.php`](diffhunk://#diff-fb147194088a5a5db28e455ae82396d41a855907016b4251d8a40338cc8281f1R40-R43): Added a null check for `$parts` after calling `wp_parse_url` to ensure the function returns null if `$parts` is null.

Fixes - https://github.com/Automattic/WPCOM-Legacy-Redirector/issues/136