### PR TITLE
ci: standardise test matrix and update readme

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -29,29 +29,18 @@ jobs:
   integration-tests:
     name: WP ${{ matrix.wordpress }} on PHP ${{ matrix.php }}${{ matrix.multisite && ' (MS)' || '' }}
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.allowed_failure }}
     timeout-minutes: 20
 
     strategy:
       fail-fast: false
       matrix:
         include:
+          # Check lowest supported WP version, with the lowest supported PHP.
           - wordpress: '6.4'
-            php: '8.1'
-            multisite: false
-            allowed_failure: false
-          - wordpress: '6.9'
-            php: '8.4'
-            multisite: false
-            allowed_failure: false
-          - wordpress: '6.9'
-            php: '8.4'
-            multisite: true
-            allowed_failure: false
+            php: '7.4'
+          # Check latest WP with the latest PHP.
           - wordpress: 'master'
-            php: '8.4'
-            multisite: false
-            allowed_failure: true
+            php: 'latest'
 
     env:
       WP_ENV_PHP_VERSION: ${{ matrix.php }}

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Please see our [wiki](https://github.com/Automattic/WPCOM-Legacy-Redirector/wiki
 ## Requirements
 
 - PHP 7.4+
-- WordPress 5.9+
+- WordPress 6.4+
 
 ## Change Log
 


### PR DESCRIPTION
## Summary

- Updates CI workflow to test against WP 6.4 and master with PHP 7.4 and latest
- Removes allowed_failure flag and multisite matrix entries to simplify the test matrix
- Updates README to reflect correct minimum WP version (6.4) matching the plugin header

## Test plan

- [ ] CI passes on WP 6.4 with PHP 7.4
- [ ] CI passes on WP master with PHP latest

🤖 Generated with [Claude Code](https://claude.com/claude-code)