### PR TITLE
fix: prevent undefined array key warning in get_redirect_data()

### DIFF
--- a/includes/class-lookup.php
+++ b/includes/class-lookup.php
@@ -136,6 +136,11 @@ final class Lookup {
 		// We need to decode the URL here to prevent $_SERVER issue from parsed data.
 		$url_info = Utils::mb_parse_url( urldecode( $url ) );
 
+		// Bail if the URL could not be parsed or has no path.
+		if ( ! is_array( $url_info ) || ! isset( $url_info['path'] ) ) {
+			return false;
+		}
+
 		$path_to_match = $url_info['path'];
 		if ( isset( $url_info['query'] ) ) {
 			$path_to_match .= '?' . $url_info['query'];

--- a/tests/Integration/LookupTest.php
+++ b/tests/Integration/LookupTest.php
@@ -57,4 +57,30 @@ final class LookupTest extends TestCase {
 		);
 	}
 
+	/**
+	 * Test Lookup::get_redirect_data returns false for URLs without a path.
+	 *
+	 * @covers Lookup::get_redirect_data
+	 * @dataProvider get_urls_without_path_data
+	 *
+	 * @param string $url URL without a path component.
+	 */
+	public function test_get_redirect_data_returns_false_for_urls_without_path( $url ) {
+		$this->assertFalse( Lookup::get_redirect_data( $url ) );
+	}
+
+	/**
+	 * Data provider for URLs without a path component.
+	 *
+	 * @return array
+	 */
+	public function get_urls_without_path_data() {
+		return array(
+			'empty string'       => array( '' ),
+			'query string only'  => array( '?foo=bar' ),
+			'fragment only'      => array( '#section' ),
+			'malformed url'      => array( '://invalid' ),
+		);
+	}
+
 }


### PR DESCRIPTION
## Summary

- Adds guard clause to check `$url_info` is an array and `path` key exists before access
- Returns `false` early for malformed URLs lacking a path component
- Prevents PHP warnings from non-human traffic with unusual URLs
- Adds integration tests for URLs without path components

## Test plan

- [x] Unit tests pass
- [x] Integration tests pass (21 tests, including 4 new test cases)
- [ ] Test with malformed URLs that lack a path component in production-like environment

Fixes #139

🤖 Generated with [Claude Code](https://claude.ai/code)