### PR TITLE
fix: only process published redirects, allowing trash to pause them

### DIFF
--- a/includes/class-lookup.php
+++ b/includes/class-lookup.php
@@ -47,7 +47,14 @@ final class Lookup {
 				wp_cache_set( $url_hash, 0, self::CACHE_GROUP );
 
 				return false;
-			} elseif ( 0 !== $redirect_post->post_parent ) {
+			}
+
+			// Only process published redirects (allows trashing to pause redirects).
+			if ( 'publish' !== $redirect_post->post_status ) {
+				return false;
+			}
+
+			if ( 0 !== $redirect_post->post_parent ) {
 				// Add preserved params to the destination URL.
 				return add_query_arg( $preservable_params, get_permalink( $redirect_post->post_parent ) );
 			} elseif ( ! empty( $redirect_post->post_excerpt ) ) {

--- a/includes/class-wpcom-legacy-redirector.php
+++ b/includes/class-wpcom-legacy-redirector.php
@@ -143,9 +143,10 @@ class WPCOM_Legacy_Redirector {
 		}
 
 		$args = array(
-			'post_name'  => $from_url_hash,
-			'post_title' => $from_url,
-			'post_type'  => Post_Type::POST_TYPE,
+			'post_name'   => $from_url_hash,
+			'post_title'  => $from_url,
+			'post_type'   => Post_Type::POST_TYPE,
+			'post_status' => 'publish',
 		);
 
 		if ( is_numeric( $redirect_to ) ) {

--- a/tests/Integration/LookupTest.php
+++ b/tests/Integration/LookupTest.php
@@ -3,10 +3,11 @@
 namespace Automattic\LegacyRedirector\Tests\Integration;
 
 use Automattic\LegacyRedirector\Lookup;
+use Automattic\LegacyRedirector\Post_Type;
 use WPCOM_Legacy_Redirector;
 
 /**
- * CapabilityTest class.
+ * LookupTest class.
  */
 final class LookupTest extends TestCase {
 
@@ -81,6 +82,66 @@ final class LookupTest extends TestCase {
 			'fragment only'      => array( '#section' ),
 			'malformed url'      => array( '://invalid' ),
 		);
+	}
+
+	/**
+	 * Test that trashed redirects do not redirect.
+	 *
+	 * @covers Lookup::get_redirect_uri
+	 */
+	public function test_trashed_redirect_does_not_redirect() {
+		$from_url = '/trashed-redirect-test';
+		$to_url   = 'http://example.com/destination';
+
+		// Insert a redirect.
+		$post_id = WPCOM_Legacy_Redirector::insert_legacy_redirect( $from_url, $to_url, false, true );
+		$this->assertIsInt( $post_id );
+
+		// Verify the redirect works initially.
+		$redirect_data = Lookup::get_redirect_data( $from_url );
+		$this->assertIsArray( $redirect_data );
+		$this->assertEquals( $to_url, $redirect_data['redirect_uri'] );
+
+		// Trash the redirect.
+		wp_trash_post( $post_id );
+
+		// Clear the cache to ensure we're testing the post_status check.
+		$url_hash = WPCOM_Legacy_Redirector::get_url_hash( $from_url );
+		wp_cache_delete( $url_hash, Lookup::CACHE_GROUP );
+
+		// Verify the redirect no longer works.
+		$redirect_data = Lookup::get_redirect_data( $from_url );
+		$this->assertFalse( $redirect_data );
+	}
+
+	/**
+	 * Test that draft redirects do not redirect.
+	 *
+	 * @covers Lookup::get_redirect_uri
+	 */
+	public function test_draft_redirect_does_not_redirect() {
+		$from_url = '/draft-redirect-test';
+		$to_url   = 'http://example.com/destination';
+
+		// Insert a redirect.
+		$post_id = WPCOM_Legacy_Redirector::insert_legacy_redirect( $from_url, $to_url, false, true );
+		$this->assertIsInt( $post_id );
+
+		// Change status to draft.
+		wp_update_post(
+			array(
+				'ID'          => $post_id,
+				'post_status' => 'draft',
+			)
+		);
+
+		// Clear the cache.
+		$url_hash = WPCOM_Legacy_Redirector::get_url_hash( $from_url );
+		wp_cache_delete( $url_hash, Lookup::CACHE_GROUP );
+
+		// Verify the redirect does not work.
+		$redirect_data = Lookup::get_redirect_data( $from_url );
+		$this->assertFalse( $redirect_data );
 	}
 
 }


### PR DESCRIPTION
## Summary

- Adds `post_status` check in `Lookup::get_redirect_uri()` — only `publish` status redirects are processed
- Fixes pre-existing bug where redirects were created as `draft` by default — now explicitly set to `publish`
- Adds integration tests for trashed and draft redirect behaviour

## Rationale

Administrators need the ability to temporarily pause redirects without deleting them. Trashing a redirect now pauses it; restoring from trash re-enables it.

## Test plan

- [x] Unit tests pass (24 tests)
- [x] Integration tests pass (19 tests, including 2 new test cases)
- [ ] Manually verify: create redirect → trash it → confirm redirect no longer works → restore → confirm it works again

Fixes #125

🤖 Generated with [Claude Code](https://claude.ai/code)