### PR TITLE
fix: CLI insert-redirect now works with post ID destination

### DIFF
--- a/includes/class-wpcom-legacy-redirector.php
+++ b/includes/class-wpcom-legacy-redirector.php
@@ -179,7 +179,7 @@ class WPCOM_Legacy_Redirector {
 			return new WP_Error( 'duplicate-redirect-uri', 'A redirect for this URI already exists' );
 		}
 		if ( is_numeric( $redirect_to ) || false !== strpos( $redirect_to, 'http' ) ) {
-			if ( is_numeric( $redirect_to ) && true !== self::vip_legacy_redirect_parent_id( $redirect_to ) ) {
+			if ( is_numeric( $redirect_to ) && true !== self::validate_destination_post_id( $redirect_to ) ) {
 				$message = __( 'Redirect is pointing to a Post ID that does not exist.', 'wpcom-legacy-redirector' );
 				return new WP_Error( 'empty-postid', $message );
 			}
@@ -413,29 +413,57 @@ class WPCOM_Legacy_Redirector {
 	}
 
 	/**
-	 * Run checks for the Post Parent ID of the redirect.
+	 * Validate a destination post ID exists and is published.
 	 *
-	 * @param object $post The Post.
-	 * @return bool|string True on success, false if parent not found, 'private' if not published.
+	 * @param int $post_id The destination post ID to validate.
+	 * @return bool True if post exists and is published, false otherwise.
+	 */
+	public static function validate_destination_post_id( $post_id ) {
+		$post = get_post( $post_id );
+		if ( ! $post instanceof \WP_Post ) {
+			return false;
+		}
+
+		// Check if redirecting to home URL (post_excerpt check for existing redirects).
+		if ( true === self::check_if_excerpt_is_home( $post_id ) ) {
+			return false;
+		}
+
+		return 'publish' === $post->post_status;
+	}
+
+	/**
+	 * Get the status of a redirect post's parent (destination).
+	 *
+	 * Used for display purposes in the admin list table.
+	 *
+	 * @param \WP_Post|int $post The redirect post object or ID.
+	 * @return string|false Parent post slug if valid and published, 'private' if not published, false if not found.
 	 */
 	public static function vip_legacy_redirect_parent_id( $post ) {
-		if ( isset( $_POST['redirect_to'] ) && true !== self::check_if_excerpt_is_home( $post ) ) {
-			if ( null !== get_post( $post ) && 'publish' === get_post_status( $post ) ) {
-				return true;
-			}
-		} else {
-			if ( is_int( $post ) ) {
-				$post = get_post( $post );
-			}
-			$parent = get_post( $post->post_parent );
-			if ( null === get_post( $post->post_parent ) ) {
-				return false;
-			} elseif ( 'publish' !== get_post_status( $parent ) ) {
-				return 'private';
-			} else {
-				$parent_slug = $parent->post_name;
-				return $parent_slug;
-			}
+		if ( is_int( $post ) ) {
+			$post = get_post( $post );
 		}
+
+		if ( ! $post instanceof \WP_Post ) {
+			return false;
+		}
+
+		// If this is not a redirect post type, treat it as a destination validation.
+		if ( Post_Type::POST_TYPE !== $post->post_type ) {
+			return self::validate_destination_post_id( $post->ID ) ? true : false;
+		}
+
+		// For redirect posts, check the parent (destination).
+		$parent = get_post( $post->post_parent );
+		if ( ! $parent instanceof \WP_Post ) {
+			return false;
+		}
+
+		if ( 'publish' !== $parent->post_status ) {
+			return 'private';
+		}
+
+		return $parent->post_name;
 	}
 }

--- a/tests/Integration/RedirectsTest.php
+++ b/tests/Integration/RedirectsTest.php
@@ -161,4 +161,61 @@ final class RedirectsTest extends TestCase {
 		$redirect = Lookup::get_redirect_uri( $protected_from );
 		$this->assertEquals( $redirect, $protected_to, 'get_redirect_uri failed' );
 	}
+
+	/**
+	 * Test redirect to a post ID works correctly (covers CLI use case).
+	 *
+	 * @covers WPCOM_Legacy_Redirector::insert_legacy_redirect
+	 * @covers WPCOM_Legacy_Redirector::validate_destination_post_id
+	 */
+	public function test_redirect_to_post_id_with_validation() {
+		// Create a published post to redirect to.
+		$destination_post_id = self::factory()->post->create(
+			array(
+				'post_status' => 'publish',
+				'post_title'  => 'Destination Post',
+			)
+		);
+
+		// Insert redirect to post ID (simulates CLI: wp wpcom-legacy-redirector insert-redirect /foo 123).
+		$result = WPCOM_Legacy_Redirector::insert_legacy_redirect( '/redirect-to-post-id', $destination_post_id, true );
+		$this->assertTrue( $result, 'insert_legacy_redirect() to post ID should succeed' );
+
+		// Verify the redirect works.
+		$redirect_uri = Lookup::get_redirect_uri( '/redirect-to-post-id' );
+		$this->assertEquals( get_permalink( $destination_post_id ), $redirect_uri );
+	}
+
+	/**
+	 * Test redirect to non-existent post ID fails validation.
+	 *
+	 * @covers WPCOM_Legacy_Redirector::insert_legacy_redirect
+	 * @covers WPCOM_Legacy_Redirector::validate_destination_post_id
+	 */
+	public function test_redirect_to_nonexistent_post_id_fails() {
+		// Use a very high post ID that doesn't exist.
+		$result = WPCOM_Legacy_Redirector::insert_legacy_redirect( '/redirect-to-nonexistent', 999999999, true );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertEquals( 'empty-postid', $result->get_error_code() );
+	}
+
+	/**
+	 * Test redirect to draft post ID fails validation.
+	 *
+	 * @covers WPCOM_Legacy_Redirector::insert_legacy_redirect
+	 * @covers WPCOM_Legacy_Redirector::validate_destination_post_id
+	 */
+	public function test_redirect_to_draft_post_id_fails() {
+		// Create a draft post.
+		$draft_post_id = self::factory()->post->create(
+			array(
+				'post_status' => 'draft',
+				'post_title'  => 'Draft Post',
+			)
+		);
+
+		$result = WPCOM_Legacy_Redirector::insert_legacy_redirect( '/redirect-to-draft', $draft_post_id, true );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertEquals( 'empty-postid', $result->get_error_code() );
+	}
 }


### PR DESCRIPTION
## Summary

- Introduces `validate_destination_post_id()` method for explicit destination post validation
- Refactors `vip_legacy_redirect_parent_id()` to detect context based on post type rather than `$_POST` superglobal
- Updates `validate_urls()` to use the new explicit validation method
- Adds integration tests for post ID destination validation

## Problem

The CLI command `wp wpcom-legacy-redirector insert-redirect /foo 5` failed with "Redirect is pointing to a Post ID that does not exist" even when post 5 existed.

The root cause was `vip_legacy_redirect_parent_id()` checking `$_POST['redirect_to']` to determine validation mode — this is only set by the UI form, not CLI operations. Without it, the function incorrectly checked the destination post's *parent* instead of whether the destination post exists.

## Test plan

- [x] Unit tests pass (24 tests)
- [x] Integration tests pass (20 tests, including 3 new test cases)
- [ ] Manually test: `wp wpcom-legacy-redirector insert-redirect /foo <post_id>` succeeds for published posts
- [ ] Manually test: same command fails for non-existent or draft posts

Fixes #117

🤖 Generated with [Claude Code](https://claude.ai/code)